### PR TITLE
Add profile DTOs and MapStruct configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,18 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.5.5.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -82,11 +94,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
                 <configuration>
+                    <source>21</source>
+                    <target>21</target>
                     <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>1.5.5.Final</version>
+                        </path>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok-mapstruct-binding</artifactId>
+                            <version>0.2.0</version>
+                        </path>
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/NotificationSettingsDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/NotificationSettingsDto.java
@@ -1,0 +1,13 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class NotificationSettingsDto {
+  private Boolean emailGeneral;
+  private Boolean emailMessage;
+  private Boolean emailFavorite;
+  private Boolean emailListingActivity;
+  private Boolean pushGeneral;
+  private String  digestFrequency; // OFF | DAILY | WEEKLY
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/NotificationSettingsUpdateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/NotificationSettingsUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class NotificationSettingsUpdateRequest {
+  private Boolean emailGeneral;
+  private Boolean emailMessage;
+  private Boolean emailFavorite;
+  private Boolean emailListingActivity;
+  private Boolean pushGeneral;
+  private String  digestFrequency;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileFeaturedItemDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileFeaturedItemDto.java
@@ -1,0 +1,9 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfileFeaturedItemDto {
+  private Long itemId;
+  private Integer idx;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileFeaturedItemsUpdateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileFeaturedItemsUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ProfileFeaturedItemsUpdateRequest {
+  private List<ProfileFeaturedItemDto> items; // {itemId, idx}
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileLinkDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileLinkDto.java
@@ -1,0 +1,13 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfileLinkDto {
+  private Long id;
+  private String type;   // INSTAGRAM, X, ...
+  private String label;
+  private String url;
+  private Integer idx;
+  private Boolean isPublic;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileLinksUpsertRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileLinksUpsertRequest.java
@@ -1,0 +1,9 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ProfileLinksUpsertRequest {
+  private List<ProfileLinkDto> links;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileOwnerDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileOwnerDto.java
@@ -1,0 +1,29 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.time.Instant;
+import java.util.List;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfileOwnerDto {
+  private Long id;
+  private Long userId;
+  private String username;
+  private String displayName;
+  private String bio;
+  private String avatarUrl;
+  private String bannerUrl;
+  private String location;
+  private String websiteUrl;
+  private String language;
+  private Boolean isVerified;
+  private Boolean isPublic;
+  private Instant createdAt;
+  private Instant updatedAt;
+
+  private List<ProfileLinkDto> links;                 // tüm linkler
+  private List<ProfileFeaturedItemDto> featuredItems;
+  private ProfilePrefsDto prefs;
+  private NotificationSettingsDto notificationSettings;
+  private ProfileStatsDto stats;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePrefsDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePrefsDto.java
@@ -1,0 +1,14 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfilePrefsDto {
+  private Boolean showEmail;
+  private Boolean showLocation;
+  private Boolean showLinks;
+  private Boolean searchable;
+  private Boolean allowDm;
+  private Boolean showCollection;
+  private Boolean showListings;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePrefsUpdateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePrefsUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ProfilePrefsUpdateRequest {
+  private Boolean showEmail;
+  private Boolean showLocation;
+  private Boolean showLinks;
+  private Boolean searchable;
+  private Boolean allowDm;
+  private Boolean showCollection;
+  private Boolean showListings;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePublicDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePublicDto.java
@@ -1,0 +1,27 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.time.Instant;
+import java.util.List;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfilePublicDto {
+  private Long id;
+  private Long userId;
+  private String username;
+  private String displayName;
+  private String bio;
+  private String avatarUrl;
+  private String bannerUrl;
+  private String location;
+  private String websiteUrl;
+  private String language;
+  private Boolean isVerified;
+  private Boolean isPublic;
+  private Instant createdAt;
+  private Instant updatedAt;
+
+  private List<ProfileLinkDto> links;                 // public görünenler
+  private List<ProfileFeaturedItemDto> featuredItems; // vitrin
+  private ProfileStatsDto stats;                      // sayaçlar
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileStatsDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileStatsDto.java
@@ -1,0 +1,14 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.time.Instant;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfileStatsDto {
+  private Integer itemsCount;
+  private Integer listingsActiveCount;
+  private Integer favoritesCount;
+  private Integer followersCount;
+  private Short   responseRate;
+  private Instant lastActiveAt;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileUpdateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class ProfileUpdateRequest {
+  @Pattern(regexp = "^[a-z0-9_]{3,32}$")
+  private String username;
+
+  @Size(max=80)
+  private String displayName;
+
+  @Size(max=500)
+  private String bio;
+
+  @Size(max=120)
+  private String location;
+
+  @Size(max=250)
+  private String websiteUrl;
+
+  @Size(max=8)
+  private String language;
+
+  private Boolean isPublic;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/UsernameAvailabilityDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/UsernameAvailabilityDto.java
@@ -1,0 +1,8 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class UsernameAvailabilityDto {
+  private boolean available;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/mapper/profile/ProfileMapper.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/mapper/profile/ProfileMapper.java
@@ -1,0 +1,49 @@
+package com.api.garagemint.garagemintapi.mapper.profile;
+
+import com.api.garagemint.garagemintapi.dto.profile.*;
+import com.api.garagemint.garagemintapi.model.*;
+import org.mapstruct.*;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface ProfileMapper {
+
+  // Entity -> DTO
+  @Mapping(target = "links", ignore = true)
+  @Mapping(target = "featuredItems", ignore = true)
+  @Mapping(target = "stats", ignore = true)
+  ProfilePublicDto toPublicDto(Profile profile);
+
+  @Mapping(target = "links", ignore = true)
+  @Mapping(target = "featuredItems", ignore = true)
+  @Mapping(target = "prefs", ignore = true)
+  @Mapping(target = "notificationSettings", ignore = true)
+  @Mapping(target = "stats", ignore = true)
+  ProfileOwnerDto toOwnerDto(Profile profile);
+
+  // Links
+  @Mapping(target = "type", expression = "java(link.getType().name())")
+  ProfileLinkDto toDto(ProfileLink link);
+  List<ProfileLinkDto> toLinkDtoList(List<ProfileLink> links);
+
+  // Prefs / Notif / Stats
+  ProfilePrefsDto toDto(ProfilePrefs prefs);
+  NotificationSettingsDto toDto(NotificationSettings ns);
+  ProfileStatsDto toDto(ProfileStats stats);
+
+  // Featured
+  @Mapping(target = "itemId", source = "id.itemId")
+  ProfileFeaturedItemDto toDto(ProfileFeaturedItem fi);
+  List<ProfileFeaturedItemDto> toFeaturedDtoList(List<ProfileFeaturedItem> list);
+
+  // Update mappings (DTO -> Entity) — owner update
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateProfileFromDto(ProfileUpdateRequest req, @MappingTarget Profile entity);
+
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updatePrefsFromDto(ProfilePrefsUpdateRequest req, @MappingTarget ProfilePrefs entity);
+
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateNotifFromDto(NotificationSettingsUpdateRequest req, @MappingTarget NotificationSettings entity);
+}


### PR DESCRIPTION
## Summary
- add profile DTOs for public and owner views, preferences, links, notifications, featured items and stats
- configure MapStruct mapper for profile entities with update mappings
- enable MapStruct build processing via new dependencies and maven compiler plugin setup

## Testing
- `mvn -q test` *(fails: Network is unreachable resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68989d17bb44832e88514560534ad3e3