### PR TITLE
Add profile initialization and username suggestions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,19 +75,25 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>org.mapstruct</groupId>
-            <artifactId>mapstruct</artifactId>
-            <version>1.5.5.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok-mapstruct-binding</artifactId>
-            <version>0.2.0</version>
-            <scope>provided</scope>
-        </dependency>
+          <dependency>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct</artifactId>
+              <version>1.5.5.Final</version>
+          </dependency>
+          <dependency>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok-mapstruct-binding</artifactId>
+              <version>0.2.0</version>
+              <scope>provided</scope>
+          </dependency>
 
-    </dependencies>
+          <dependency>
+              <groupId>org.springdoc</groupId>
+              <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+              <version>2.5.0</version>
+          </dependency>
+
+      </dependencies>
 
     <build>
         <plugins>

--- a/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
@@ -1,0 +1,22 @@
+package com.api.garagemint.garagemintapi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.*;
+
+@Configuration
+public class CorsConfig {
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowCredentials(true);
+      }
+    };
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/ApiExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.api.garagemint.garagemintapi.controller;
+
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import org.springframework.http.*;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+  // Hata cevabı sözleşmesi
+  public record ApiError(Instant timestamp, int status, String error, String message, Map<String, String> fields) { }
+
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<ApiError> handleNotFound(NotFoundException ex) {
+    return build(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), null);
+  }
+
+  @ExceptionHandler(ValidationException.class)
+  public ResponseEntity<ApiError> handleValidation(ValidationException ex) {
+    return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), null);
+  }
+
+  @ExceptionHandler(BusinessRuleException.class)
+  public ResponseEntity<ApiError> handleBusiness(BusinessRuleException ex) {
+    return build(HttpStatus.CONFLICT, "BUSINESS_RULE_VIOLATION", ex.getMessage(), null);
+  }
+
+  // Bean Validation (@Valid) alan hataları
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiError> handleBeanValidation(MethodArgumentNotValidException ex) {
+    Map<String,String> fields = new LinkedHashMap<>();
+    ex.getBindingResult().getFieldErrors()
+        .forEach(fe -> fields.put(fe.getField(), fe.getDefaultMessage()));
+    return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "Invalid request", fields);
+  }
+
+  // En sonda genel yakalayıcı
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiError> handleOther(Exception ex) {
+    return build(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage(), null);
+  }
+
+  private ResponseEntity<ApiError> build(HttpStatus s, String code, String msg, Map<String,String> fields) {
+    return ResponseEntity.status(s)
+        .body(new ApiError(Instant.now(), s.value(), code, msg, fields));
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileController.java
@@ -4,11 +4,12 @@ import com.api.garagemint.garagemintapi.dto.profile.*;
 import com.api.garagemint.garagemintapi.service.profile.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/profiles")
+@RequestMapping(value = "/api/v1/profiles", produces = "application/json")
 @RequiredArgsConstructor
 public class ProfileController {
 
@@ -26,8 +27,20 @@ public class ProfileController {
         return profileService.checkUsernameAvailability(username);
     }
 
+    // Kullanıcı adı önerileri (autocomplete)
+    @GetMapping("/suggest-username")
+    public UsernameSuggestionsDto suggestUsername(@RequestParam(required = false) String base) {
+        return profileService.suggestUsernames(base);
+    }
+
     // ---- Owner Endpoints (mock userId = 1L) ----
-    // Gerçekte userId SecurityContext'ten alınacak
+    // TODO: Gerçekte userId SecurityContext'ten alınacak
+
+    // Profil yoksa oluştur + getir (idempotent)
+    @PostMapping("/me/init")
+    public ProfileOwnerDto initMyProfile() {
+        return profileService.ensureMyProfile(1L);
+    }
 
     @GetMapping("/me")
     public ProfileOwnerDto getMyProfile() {
@@ -35,7 +48,7 @@ public class ProfileController {
     }
 
     @PutMapping("/me")
-    public ProfileOwnerDto updateMyProfile(@RequestBody ProfileUpdateRequest req) {
+    public ProfileOwnerDto updateMyProfile(@Valid @RequestBody ProfileUpdateRequest req) {
         return profileService.updateMyProfile(1L, req);
     }
 
@@ -50,22 +63,22 @@ public class ProfileController {
     }
 
     @PutMapping("/me/links")
-    public List<ProfileLinkDto> updateMyLinks(@RequestBody List<ProfileLinkDto> links) {
+    public List<ProfileLinkDto> updateMyLinks(@RequestBody List<@Valid ProfileLinkDto> links) {
         return profileService.upsertMyLinks(1L, links);
     }
 
     @PutMapping("/me/prefs")
-    public ProfilePrefsDto updateMyPrefs(@RequestBody ProfilePrefsUpdateRequest req) {
+    public ProfilePrefsDto updateMyPrefs(@Valid @RequestBody ProfilePrefsUpdateRequest req) {
         return profileService.updateMyPrefs(1L, req);
     }
 
     @PutMapping("/me/notifications")
-    public NotificationSettingsDto updateMyNotifications(@RequestBody NotificationSettingsUpdateRequest req) {
+    public NotificationSettingsDto updateMyNotifications(@Valid @RequestBody NotificationSettingsUpdateRequest req) {
         return profileService.updateMyNotificationSettings(1L, req);
     }
 
     @PutMapping("/me/featured")
-    public List<ProfileFeaturedItemDto> updateMyFeatured(@RequestBody List<ProfileFeaturedItemDto> items) {
+    public List<ProfileFeaturedItemDto> updateMyFeatured(@RequestBody List<@Valid ProfileFeaturedItemDto> items) {
         return profileService.updateMyFeaturedItems(1L, items);
     }
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/UsernameSuggestionsDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/UsernameSuggestionsDto.java
@@ -1,0 +1,9 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class UsernameSuggestionsDto {
+  private List<String> candidates;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,14 @@ spring:
       hibernate:
         format_sql: true
 
-management:
-  endpoints:
-    web:
-      exposure:
-        include: "health,info"
+  management:
+    endpoints:
+      web:
+        exposure:
+          include: "health,info"
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger


### PR DESCRIPTION
## Summary
- add global ApiExceptionHandler with structured error responses
- configure CORS for Next.js frontend
- implement profile initialization, username suggestions, and helper methods
- extend profile controller with initialization and suggestion endpoints
- add Swagger UI starter and configuration

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c948df98832e9a00778e5ed28c91