### PR TITLE
Add car listing domain entities

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Brand.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Brand.java
@@ -1,0 +1,29 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import com.api.garagemint.garagemintapi.model.profile.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "brands",
+       indexes = {
+         @Index(name="idx_brands_name", columnList = "name"),
+         @Index(name="idx_brands_slug", columnList = "slug", unique = true)
+       })
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class Brand extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable=false, length=80)
+  private String name;
+
+  @Column(nullable=false, length=80, unique=true)
+  private String slug;
+
+  @Column(length=80)
+  private String country;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Condition.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Condition.java
@@ -1,0 +1,4 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+public enum Condition { NEW, MINT, USED, CUSTOM }
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Listing.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Listing.java
@@ -1,0 +1,88 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import com.api.garagemint.garagemintapi.model.profile.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "listings",
+       indexes = {
+         @Index(name="idx_listings_status_created", columnList = "status,created_at"),
+         @Index(name="idx_listings_seller", columnList = "seller_user_id"),
+         @Index(name="idx_listings_brand", columnList = "brand_id"),
+         @Index(name="idx_listings_series", columnList = "series_id"),
+         @Index(name="idx_listings_theme", columnList = "theme"),
+         @Index(name="idx_listings_limited", columnList = "limited_edition")
+       })
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class Listing extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /** users.id (FK – ilişki kurulmuyor, sadece sütun) */
+  @Column(name="seller_user_id", nullable=false)
+  private Long sellerUserId;
+
+  /** brands.id (FK – opsiyonel) */
+  @Column(name="brand_id")
+  private Long brandId;
+
+  /** series.id (FK – opsiyonel) */
+  @Column(name="series_id")
+  private Long seriesId;
+
+  @Column(nullable=false, length=180)
+  private String title;
+
+  @Lob
+  @Column(columnDefinition = "TEXT")
+  private String description;
+
+  @Column(name="model_name", length=180)
+  private String modelName;
+
+  @Column(length=16)
+  private String scale;
+
+  @Column(name="year_made")
+  private Short year;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length=24)
+  private Condition condition;
+
+  @Column(name="limited_edition")
+  private Boolean limitedEdition = Boolean.FALSE;
+
+  @Column(length=80)
+  private String theme;
+
+  @Column(name="country_of_origin", length=64)
+  private String countryOfOrigin;
+
+  // ---- Pricing ----
+  @Enumerated(EnumType.STRING)
+  @Column(length=16, nullable=false)
+  private ListingType type;
+
+  private BigDecimal price;
+
+  @Column(length=3)
+  private String currency;
+
+  @Column(length=120)
+  private String location;
+
+  @Enumerated(EnumType.STRING)
+  @Column(length=16)
+  private ListingStatus status;
+
+  /** Admin moderasyonu için; false → feed’de görünmesin */
+  @Column(name="is_active")
+  private Boolean isActive = Boolean.TRUE;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingImage.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingImage.java
@@ -1,0 +1,27 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import com.api.garagemint.garagemintapi.model.profile.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "listing_images",
+       uniqueConstraints = @UniqueConstraint(name="ux_listing_image_idx", columnNames = {"listing_id","idx"}),
+       indexes = @Index(name="idx_listing_images_listing", columnList = "listing_id"))
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class ListingImage extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name="listing_id", nullable=false)
+  private Long listingId;
+
+  @Column(nullable=false, length=500)
+  private String url;
+
+  @Column(nullable=false)
+  private Integer idx;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingStatus.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingStatus.java
@@ -1,0 +1,4 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+public enum ListingStatus { ACTIVE, SOLD, WITHDRAWN }
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingTag.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingTag.java
@@ -1,0 +1,20 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import com.api.garagemint.garagemintapi.model.profile.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "listing_tags",
+       indexes = {
+         @Index(name="idx_listing_tags_listing", columnList = "listing_id"),
+         @Index(name="idx_listing_tags_tag", columnList = "tag_id")
+       })
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class ListingTag extends BaseTime {
+
+  @EmbeddedId
+  private ListingTagId id;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingTagId.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingTagId.java
@@ -1,0 +1,13 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+import java.io.Serializable;
+
+@Embeddable
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @EqualsAndHashCode
+public class ListingTagId implements Serializable {
+  private Long listingId;
+  private Long tagId;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingType.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/ListingType.java
@@ -1,0 +1,4 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+public enum ListingType { SALE, TRADE }
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Series.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Series.java
@@ -1,0 +1,33 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import com.api.garagemint.garagemintapi.model.profile.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "series",
+       uniqueConstraints = {
+         @UniqueConstraint(name="ux_series_brand_slug", columnNames = {"brand_id","slug"})
+       },
+       indexes = {
+         @Index(name="idx_series_brand", columnList = "brand_id"),
+         @Index(name="idx_series_slug", columnList = "slug")
+       })
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class Series extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /** brands.id (FK – ilişki kurulmuyor, sadece sütun) */
+  @Column(name="brand_id")
+  private Long brandId;
+
+  @Column(nullable=false, length=80)
+  private String name;
+
+  @Column(nullable=false, length=80)
+  private String slug;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Tag.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Tag.java
@@ -1,0 +1,26 @@
+package com.api.garagemint.garagemintapi.model.cars;
+
+import com.api.garagemint.garagemintapi.model.profile.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "tags",
+       indexes = {
+         @Index(name="idx_tags_name", columnList = "name"),
+         @Index(name="idx_tags_slug", columnList = "slug", unique = true)
+       })
+@Getter @Setter @Builder
+@NoArgsConstructor @AllArgsConstructor
+public class Tag extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable=false, length=80)
+  private String name;
+
+  @Column(nullable=false, length=80, unique=true)
+  private String slug;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/model/profile/common/BaseTime.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/profile/common/BaseTime.java
@@ -1,0 +1,20 @@
+package com.api.garagemint.garagemintapi.model.profile.common;
+
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseTime {
+
+    @CreationTimestamp
+    protected Instant createdAt;
+
+    @UpdateTimestamp
+    protected Instant updatedAt;
+}
+


### PR DESCRIPTION
## Summary
- add brand, series, tag entities for cars
- introduce listing, image, and tag mapping entities with enum types
- provide BaseTime under profile.common for timestamp inheritance

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6063d3b38832e8f3f3238069a1110