### PR TITLE
feat: add car repositories and services

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/BrandRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/BrandRepository.java
@@ -1,0 +1,11 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.model.cars.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BrandRepository extends JpaRepository<Brand, Long> {
+  Optional<Brand> findBySlug(String slug);
+  boolean existsBySlug(String slug);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingImageRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingImageRepository.java
@@ -1,0 +1,11 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.model.cars.ListingImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ListingImageRepository extends JpaRepository<ListingImage, Long> {
+  List<ListingImage> findByListingIdOrderByIdxAsc(Long listingId);
+  void deleteByListingId(Long listingId);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingQueryRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingQueryRepository.java
@@ -1,0 +1,10 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.ListingFilterRequest;
+import com.api.garagemint.garagemintapi.model.cars.Listing;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ListingQueryRepository {
+  Page<Listing> search(ListingFilterRequest filter, Pageable pageable);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingQueryRepositoryImpl.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingQueryRepositoryImpl.java
@@ -1,0 +1,74 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.ListingFilterRequest;
+import com.api.garagemint.garagemintapi.model.cars.Condition;
+import com.api.garagemint.garagemintapi.model.cars.Listing;
+import com.api.garagemint.garagemintapi.model.cars.ListingStatus;
+import com.api.garagemint.garagemintapi.model.cars.ListingType;
+import jakarta.persistence.*;
+import jakarta.persistence.criteria.*;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class ListingQueryRepositoryImpl implements ListingQueryRepository {
+
+  @PersistenceContext
+  private EntityManager em;
+
+  @Override
+  public Page<Listing> search(ListingFilterRequest f, Pageable pageable) {
+    CriteriaBuilder cb = em.getCriteriaBuilder();
+
+    CriteriaQuery<Listing> cq = cb.createQuery(Listing.class);
+    Root<Listing> root = cq.from(Listing.class);
+
+    List<Predicate> ps = new ArrayList<>();
+
+    // Moderasyon ve durum varsayılanları
+    if (f.getStatus() == null || f.getStatus().isBlank()) {
+      ps.add(cb.equal(root.get("status"), ListingStatus.ACTIVE));
+    } else {
+      ps.add(cb.equal(root.get("status"), ListingStatus.valueOf(f.getStatus().toUpperCase())));
+    }
+    ps.add(cb.isTrue(root.get("isActive")));
+
+    if (f.getSellerUserId() != null) ps.add(cb.equal(root.get("sellerUserId"), f.getSellerUserId()));
+    if (f.getBrandIds() != null && !f.getBrandIds().isEmpty()) ps.add(root.get("brandId").in(f.getBrandIds()));
+    if (f.getSeriesIds() != null && !f.getSeriesIds().isEmpty()) ps.add(root.get("seriesId").in(f.getSeriesIds()));
+    if (f.getTheme() != null && !f.getTheme().isBlank()) ps.add(cb.equal(cb.lower(root.get("theme")), f.getTheme().toLowerCase()));
+    if (f.getScale() != null && !f.getScale().isBlank()) ps.add(cb.equal(root.get("scale"), f.getScale()));
+    if (f.getCondition() != null && !f.getCondition().isBlank()) ps.add(cb.equal(root.get("condition"), Condition.valueOf(f.getCondition().toUpperCase())));
+    if (f.getLimitedEdition() != null) ps.add(cb.equal(root.get("limitedEdition"), f.getLimitedEdition()));
+    if (f.getType() != null && !f.getType().isBlank()) ps.add(cb.equal(root.get("type"), ListingType.valueOf(f.getType().toUpperCase())));
+    if (f.getLocation() != null && !f.getLocation().isBlank()) ps.add(cb.like(cb.lower(root.get("location")), "%" + f.getLocation().toLowerCase() + "%"));
+    if (f.getYearFrom() != null) ps.add(cb.greaterThanOrEqualTo(root.get("year"), f.getYearFrom()));
+    if (f.getYearTo() != null) ps.add(cb.lessThanOrEqualTo(root.get("year"), f.getYearTo()));
+    if (f.getPriceMin() != null) ps.add(cb.greaterThanOrEqualTo(root.get("price"), f.getPriceMin()));
+    if (f.getPriceMax() != null) ps.add(cb.lessThanOrEqualTo(root.get("price"), f.getPriceMax()));
+
+    cq.where(ps.toArray(Predicate[]::new));
+
+    Path<?> sortPath = switch (f.getSortBy()) {
+      case "price" -> root.get("price");
+      case "year"  -> root.get("year");
+      default -> root.get("createdAt");
+    };
+    cq.orderBy("ASC".equalsIgnoreCase(f.getSortDir()) ? cb.asc(sortPath) : cb.desc(sortPath));
+
+    TypedQuery<Listing> q = em.createQuery(cq);
+    q.setFirstResult((int) pageable.getOffset());
+    q.setMaxResults(pageable.getPageSize());
+    List<Listing> content = q.getResultList();
+
+    CriteriaQuery<Long> countQ = cb.createQuery(Long.class);
+    Root<Listing> countRoot = countQ.from(Listing.class);
+    countQ.select(cb.count(countRoot)).where(ps.toArray(Predicate[]::new));
+    Long total = em.createQuery(countQ).getSingleResult();
+
+    return new PageImpl<>(content, pageable, total);
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingRepository.java
@@ -1,0 +1,12 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.model.cars.Listing;
+import com.api.garagemint.garagemintapi.model.cars.ListingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ListingRepository extends JpaRepository<Listing, Long> {
+  long countBySellerUserIdAndStatus(Long sellerUserId, ListingStatus status);
+  List<Listing> findBySellerUserIdAndStatus(Long sellerUserId, ListingStatus status);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingTagRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingTagRepository.java
@@ -1,0 +1,12 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.model.cars.ListingTag;
+import com.api.garagemint.garagemintapi.model.cars.ListingTagId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ListingTagRepository extends JpaRepository<ListingTag, ListingTagId> {
+  List<ListingTag> findByIdListingId(Long listingId);
+  void deleteByIdListingId(Long listingId);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/SeriesRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/SeriesRepository.java
@@ -1,0 +1,11 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.model.cars.Series;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+  List<Series> findByBrandId(Long brandId);
+  boolean existsByBrandIdAndSlug(Long brandId, String slug);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/TagRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/TagRepository.java
@@ -1,0 +1,11 @@
+package com.api.garagemint.garagemintapi.repository.cars;
+
+import com.api.garagemint.garagemintapi.model.cars.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+  List<Tag> findByIdIn(List<Long> ids);
+  boolean existsBySlug(String slug);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/cars/BrandService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/cars/BrandService.java
@@ -1,0 +1,60 @@
+package com.api.garagemint.garagemintapi.service.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.BrandDto;
+import com.api.garagemint.garagemintapi.mapper.cars.BrandMapper;
+import com.api.garagemint.garagemintapi.model.cars.Brand;
+import com.api.garagemint.garagemintapi.repository.cars.BrandRepository;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service @RequiredArgsConstructor
+public class BrandService {
+
+  private final BrandRepository brandRepo;
+  private final BrandMapper brandMapper;
+
+  @Transactional
+  public BrandDto create(BrandDto dto) {
+    if (dto == null) throw new ValidationException("body is required");
+    if (dto.getSlug() == null || dto.getSlug().isBlank()) throw new ValidationException("slug is required");
+    if (brandRepo.existsBySlug(dto.getSlug())) throw new BusinessRuleException("slug already exists");
+    var e = Brand.builder().name(dto.getName()).slug(dto.getSlug()).country(dto.getCountry()).build();
+    return brandMapper.toDto(brandRepo.save(e));
+  }
+
+  @Transactional(readOnly = true)
+  public BrandDto get(Long id) {
+    return brandRepo.findById(id).map(brandMapper::toDto)
+        .orElseThrow(() -> new NotFoundException("Brand not found"));
+  }
+
+  @Transactional(readOnly = true)
+  public List<BrandDto> list() {
+    return brandRepo.findAll().stream().map(brandMapper::toDto).toList();
+  }
+
+  @Transactional
+  public BrandDto update(Long id, BrandDto dto) {
+    var e = brandRepo.findById(id).orElseThrow(() -> new NotFoundException("Brand not found"));
+    if (dto.getName() != null) e.setName(dto.getName());
+    if (dto.getCountry() != null) e.setCountry(dto.getCountry());
+    if (dto.getSlug() != null) {
+      if (!dto.getSlug().equals(e.getSlug()) && brandRepo.existsBySlug(dto.getSlug()))
+        throw new BusinessRuleException("slug already exists");
+      e.setSlug(dto.getSlug());
+    }
+    return brandMapper.toDto(brandRepo.save(e));
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    if (!brandRepo.existsById(id)) throw new NotFoundException("Brand not found");
+    brandRepo.deleteById(id);
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/cars/ListingService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/cars/ListingService.java
@@ -1,0 +1,272 @@
+package com.api.garagemint.garagemintapi.service.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.*;
+import com.api.garagemint.garagemintapi.mapper.cars.ListingMapper;
+import com.api.garagemint.garagemintapi.model.cars.*;
+import com.api.garagemint.garagemintapi.model.profile.Profile;
+import com.api.garagemint.garagemintapi.repository.ProfileRepository;
+import com.api.garagemint.garagemintapi.repository.cars.*;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service @RequiredArgsConstructor
+public class ListingService {
+
+  private static final int MAX_ACTIVE_LISTINGS_FREE = 3;
+
+  private final ListingRepository listingRepo;
+  private final ListingQueryRepository listingQueryRepo;
+  private final ListingImageRepository imageRepo;
+  private final ListingTagRepository listingTagRepo;
+  private final TagRepository tagRepo;
+  private final BrandRepository brandRepo;
+  private final SeriesRepository seriesRepo;
+  private final ProfileRepository profileRepo;
+  private final ListingMapper mapper;
+
+  /* =============== CREATE =============== */
+
+  @Transactional
+  public ListingResponseDto create(Long sellerUserId, ListingCreateRequest req) {
+    validateCreate(req);
+
+    // active quota
+    long activeCount = listingRepo.countBySellerUserIdAndStatus(sellerUserId, ListingStatus.ACTIVE);
+    if (activeCount >= MAX_ACTIVE_LISTINGS_FREE)
+      throw new BusinessRuleException("maximum active listings reached: " + MAX_ACTIVE_LISTINGS_FREE);
+
+    var entity = mapper.toEntity(req);
+    entity.setSellerUserId(sellerUserId);
+    entity.setStatus(ListingStatus.ACTIVE);
+    entity.setIsActive(Boolean.TRUE);
+
+    // SALE → price/currency zorunlu
+    if (entity.getType() == ListingType.SALE) {
+      if (entity.getPrice() == null || entity.getPrice().compareTo(BigDecimal.ZERO) <= 0)
+        throw new ValidationException("price must be > 0 for SALE");
+      if (req.getCurrency() == null || req.getCurrency().isBlank())
+        throw new ValidationException("currency is required for SALE");
+      entity.setCurrency(req.getCurrency());
+    } else {
+      entity.setPrice(null);
+      entity.setCurrency(null);
+    }
+
+    // existence checks
+    if (entity.getBrandId() != null) ensureBrandExists(entity.getBrandId());
+    if (entity.getSeriesId() != null) ensureSeriesExists(entity.getSeriesId());
+
+    var saved = listingRepo.save(entity);
+
+    // replace semantics
+    upsertImagesInternal(saved.getId(), req.getImages());
+    upsertTagsInternal(saved.getId(), req.getTagIds());
+
+    return assembleResponse(saved.getId());
+  }
+
+  /* =============== READ =============== */
+
+  @Transactional(readOnly = true)
+  public ListingResponseDto getPublicById(Long id) {
+    var e = listingRepo.findById(id).orElseThrow(() -> new NotFoundException("Listing not found"));
+    if (!Boolean.TRUE.equals(e.getIsActive()) || e.getStatus() != ListingStatus.ACTIVE)
+      throw new NotFoundException("Listing not available");
+    return assembleResponse(id);
+  }
+
+  @Transactional(readOnly = true)
+  public ListingResponseDto getMyById(Long sellerUserId, Long id) {
+    var e = load(id);
+    ensureOwner(sellerUserId, e);
+    return assembleResponse(id);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<ListingResponseDto> search(ListingFilterRequest filter) {
+    Pageable pageable = PageRequest.of(
+        Optional.ofNullable(filter.getPage()).orElse(0),
+        Optional.ofNullable(filter.getSize()).orElse(20)
+    );
+    var page = listingQueryRepo.search(filter, pageable);
+
+    // NOTE: assembleResponse her id için ayrı repository çağrıları yapar; büyürse DTO projection optimize edilir.
+    var dtos = page.getContent().stream().map(l -> assembleResponse(l.getId())).toList();
+    return new PageImpl<>(dtos, pageable, page.getTotalElements());
+  }
+
+  @Transactional(readOnly = true)
+  public List<ListingResponseDto> listMyActive(Long sellerUserId) {
+    return listingRepo.findBySellerUserIdAndStatus(sellerUserId, ListingStatus.ACTIVE)
+        .stream().map(l -> assembleResponse(l.getId())).toList();
+  }
+
+  /* =============== UPDATE =============== */
+
+  @Transactional
+  public ListingResponseDto update(Long sellerUserId, Long id, ListingUpdateRequest req) {
+    var e = load(id);
+    ensureOwner(sellerUserId, e);
+
+    var oldType = e.getType();
+    mapper.updateEntity(e, req);
+
+    // brand/series checks if changed
+    if (req.getBrandId() != null) ensureBrandExists(e.getBrandId());
+    if (req.getSeriesId() != null) ensureSeriesExists(e.getSeriesId());
+
+    // SALE rule if type or price changed
+    if (e.getType() == ListingType.SALE) {
+      if (e.getPrice() == null || e.getPrice().compareTo(BigDecimal.ZERO) <= 0)
+        throw new ValidationException("price must be > 0 for SALE");
+      if (e.getCurrency() == null || e.getCurrency().isBlank())
+        throw new ValidationException("currency is required for SALE");
+    } else {
+      e.setPrice(null);
+      e.setCurrency(null);
+    }
+
+    // Images/Tags full replace if provided
+    if (req.getImages() != null) upsertImagesInternal(id, req.getImages());
+    if (req.getTagIds() != null) upsertTagsInternal(id, req.getTagIds());
+
+    listingRepo.save(e);
+    return assembleResponse(id);
+  }
+
+  /* =============== STATUS/MODERATION =============== */
+
+  @Transactional
+  public ListingResponseDto patchStatus(Long sellerUserId, Long id, String statusStr) {
+    var e = load(id);
+    ensureOwner(sellerUserId, e);
+    if (statusStr == null || statusStr.isBlank()) throw new ValidationException("status is required");
+    e.setStatus(ListingStatus.valueOf(statusStr.toUpperCase()));
+    listingRepo.save(e);
+    return assembleResponse(id);
+  }
+
+  @Transactional
+  public ListingResponseDto moderate(Long id, Boolean isActive, String statusStr) {
+    var e = load(id);
+    if (isActive != null) e.setIsActive(isActive);
+    if (statusStr != null && !statusStr.isBlank()) e.setStatus(ListingStatus.valueOf(statusStr.toUpperCase()));
+    listingRepo.save(e);
+    return assembleResponse(id);
+  }
+
+  /* =============== IMAGES/TAGS REPLACE APIs =============== */
+
+  @Transactional
+  public List<ListingImageDto> replaceImages(Long sellerUserId, Long id, List<ListingImageUpsertDto> images) {
+    var e = load(id);
+    ensureOwner(sellerUserId, e);
+    return upsertImagesInternal(id, images);
+  }
+
+  @Transactional
+  public List<TagDto> replaceTags(Long sellerUserId, Long id, List<Long> tagIds) {
+    var e = load(id);
+    ensureOwner(sellerUserId, e);
+    return upsertTagsInternal(id, tagIds);
+  }
+
+  /* =============== DELETE =============== */
+
+  @Transactional
+  public void delete(Long sellerUserId, Long id) {
+    var e = load(id);
+    ensureOwner(sellerUserId, e);
+    // önce child kayıtlar
+    imageRepo.deleteByListingId(id);
+    listingTagRepo.deleteByIdListingId(id);
+    listingRepo.deleteById(id);
+  }
+
+  /* =============== HELPERS =============== */
+
+  private Listing load(Long id) {
+    return listingRepo.findById(id).orElseThrow(() -> new NotFoundException("Listing not found"));
+  }
+
+  private void ensureOwner(Long sellerUserId, Listing e) {
+    if (!Objects.equals(e.getSellerUserId(), sellerUserId))
+      throw new BusinessRuleException("not your listing");
+  }
+
+  private void ensureBrandExists(Long id) {
+    brandRepo.findById(id).orElseThrow(() -> new ValidationException("brand not found: " + id));
+  }
+
+  private void ensureSeriesExists(Long id) {
+    seriesRepo.findById(id).orElseThrow(() -> new ValidationException("series not found: " + id));
+  }
+
+  private void validateCreate(ListingCreateRequest req) {
+    if (req == null) throw new ValidationException("body is required");
+    if (req.getTitle() == null || req.getTitle().isBlank()) throw new ValidationException("title is required");
+    if (req.getType() == null || req.getType().isBlank()) throw new ValidationException("type is required");
+  }
+
+  private List<ListingImageDto> upsertImagesInternal(Long listingId, List<ListingImageUpsertDto> images) {
+    imageRepo.deleteByListingId(listingId);
+    if (images == null || images.isEmpty()) return List.of();
+    var entities = images.stream()
+        .sorted(Comparator.comparingInt(ListingImageUpsertDto::getIdx))
+        .map(i -> com.api.garagemint.garagemintapi.model.cars.ListingImage.builder()
+            .listingId(listingId).url(i.getUrl().trim()).idx(i.getIdx()).build())
+        .toList();
+    return mapper.toImageDtoList(imageRepo.saveAll(entities));
+  }
+
+  private List<TagDto> upsertTagsInternal(Long listingId, List<Long> tagIds) {
+    listingTagRepo.deleteByIdListingId(listingId);
+    if (tagIds == null || tagIds.isEmpty()) return List.of();
+    var uniqueIds = tagIds.stream().filter(Objects::nonNull).collect(Collectors.toCollection(LinkedHashSet::new));
+    var tags = tagRepo.findByIdIn(new ArrayList<>(uniqueIds));
+    var pairs = tags.stream()
+        .map(t -> new ListingTag(new ListingTagId(listingId, t.getId())))
+        .toList();
+    listingTagRepo.saveAll(pairs);
+    return mapper.toTagDtoList(tags);
+  }
+
+  private ListingResponseDto assembleResponse(Long id) {
+    var e = load(id);
+    var dto = mapper.toResponseDto(e);
+
+    // images
+    var images = imageRepo.findByListingIdOrderByIdxAsc(id);
+    dto.setImages(mapper.toImageDtoList(images));
+
+    // tags
+    var lt = listingTagRepo.findByIdListingId(id);
+    var tagIds = lt.stream().map(x -> x.getId().getTagId()).toList();
+    var tags = tagRepo.findByIdIn(tagIds);
+    dto.setTags(mapper.toTagDtoList(tags));
+
+    // seller
+    Profile seller = profileRepo.findByUserId(e.getSellerUserId()).orElse(null);
+    if (seller != null) {
+      dto.setSeller(new com.api.garagemint.garagemintapi.dto.cars.ListingSellerDto(
+          seller.getUserId(), seller.getUsername(), seller.getDisplayName(),
+          seller.getAvatarUrl(), seller.getLocation()
+      ));
+    }
+
+    // brand/series names (opsiyonel enrich)
+    if (e.getBrandId() != null) brandRepo.findById(e.getBrandId()).ifPresent(b -> dto.setBrandName(b.getName()));
+    if (e.getSeriesId() != null) seriesRepo.findById(e.getSeriesId()).ifPresent(s -> dto.setSeriesName(s.getName()));
+
+    return dto;
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/cars/SeriesService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/cars/SeriesService.java
@@ -1,0 +1,61 @@
+package com.api.garagemint.garagemintapi.service.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.SeriesDto;
+import com.api.garagemint.garagemintapi.mapper.cars.SeriesMapper;
+import com.api.garagemint.garagemintapi.model.cars.Series;
+import com.api.garagemint.garagemintapi.repository.cars.SeriesRepository;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service @RequiredArgsConstructor
+public class SeriesService {
+
+  private final SeriesRepository seriesRepo;
+  private final SeriesMapper seriesMapper;
+
+  @Transactional
+  public SeriesDto create(SeriesDto dto) {
+    if (dto == null) throw new ValidationException("body is required");
+    if (dto.getBrandId() == null) throw new ValidationException("brandId is required");
+    if (dto.getSlug() == null || dto.getSlug().isBlank()) throw new ValidationException("slug is required");
+    if (seriesRepo.existsByBrandIdAndSlug(dto.getBrandId(), dto.getSlug()))
+      throw new BusinessRuleException("slug already exists for this brand");
+    var e = Series.builder().brandId(dto.getBrandId()).name(dto.getName()).slug(dto.getSlug()).build();
+    return seriesMapper.toDto(seriesRepo.save(e));
+  }
+
+  @Transactional(readOnly = true)
+  public SeriesDto get(Long id) {
+    return seriesRepo.findById(id).map(seriesMapper::toDto)
+        .orElseThrow(() -> new NotFoundException("Series not found"));
+  }
+
+  @Transactional(readOnly = true)
+  public List<SeriesDto> listByBrand(Long brandId) {
+    return seriesRepo.findByBrandId(brandId).stream().map(seriesMapper::toDto).toList();
+  }
+
+  @Transactional
+  public SeriesDto update(Long id, SeriesDto dto) {
+    var e = seriesRepo.findById(id).orElseThrow(() -> new NotFoundException("Series not found"));
+    if (dto.getName() != null) e.setName(dto.getName());
+    if (dto.getSlug() != null) {
+      if (!dto.getSlug().equals(e.getSlug()) && seriesRepo.existsByBrandIdAndSlug(e.getBrandId(), dto.getSlug()))
+        throw new BusinessRuleException("slug already exists for this brand");
+      e.setSlug(dto.getSlug());
+    }
+    return seriesMapper.toDto(seriesRepo.save(e));
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    if (!seriesRepo.existsById(id)) throw new NotFoundException("Series not found");
+    seriesRepo.deleteById(id);
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/cars/TagService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/cars/TagService.java
@@ -1,0 +1,59 @@
+package com.api.garagemint.garagemintapi.service.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.TagDto;
+import com.api.garagemint.garagemintapi.mapper.cars.TagMapper;
+import com.api.garagemint.garagemintapi.model.cars.Tag;
+import com.api.garagemint.garagemintapi.repository.cars.TagRepository;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service @RequiredArgsConstructor
+public class TagService {
+
+  private final TagRepository tagRepo;
+  private final TagMapper tagMapper;
+
+  @Transactional
+  public TagDto create(TagDto dto) {
+    if (dto == null) throw new ValidationException("body is required");
+    if (dto.getSlug() == null || dto.getSlug().isBlank()) throw new ValidationException("slug is required");
+    if (tagRepo.existsBySlug(dto.getSlug())) throw new BusinessRuleException("slug already exists");
+    var e = Tag.builder().name(dto.getName()).slug(dto.getSlug()).build();
+    return tagMapper.toDto(tagRepo.save(e));
+  }
+
+  @Transactional(readOnly = true)
+  public TagDto get(Long id) {
+    return tagRepo.findById(id).map(tagMapper::toDto)
+        .orElseThrow(() -> new NotFoundException("Tag not found"));
+  }
+
+  @Transactional(readOnly = true)
+  public List<TagDto> list() {
+    return tagRepo.findAll().stream().map(tagMapper::toDto).toList();
+  }
+
+  @Transactional
+  public TagDto update(Long id, TagDto dto) {
+    var e = tagRepo.findById(id).orElseThrow(() -> new NotFoundException("Tag not found"));
+    if (dto.getName() != null) e.setName(dto.getName());
+    if (dto.getSlug() != null) {
+      if (!dto.getSlug().equals(e.getSlug()) && tagRepo.existsBySlug(dto.getSlug()))
+        throw new BusinessRuleException("slug already exists");
+      e.setSlug(dto.getSlug());
+    }
+    return tagMapper.toDto(tagRepo.save(e));
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    if (!tagRepo.existsById(id)) throw new NotFoundException("Tag not found");
+    tagRepo.deleteById(id);
+  }
+}


### PR DESCRIPTION
## Summary
- add JPA repositories for car domain entities and listing search
- implement services for managing brands, series, tags, and listings with full replace semantics for images and tags

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a753872b14832e99c82048e4623b45