### PR TITLE
Refactor listing year to modelYear and seed car data

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/TestDataLoader.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/TestDataLoader.java
@@ -2,100 +2,194 @@ package com.api.garagemint.garagemintapi;
 
 import com.api.garagemint.garagemintapi.model.profile.*;
 import com.api.garagemint.garagemintapi.repository.*;
+import com.api.garagemint.garagemintapi.model.cars.*;
+import com.api.garagemint.garagemintapi.repository.cars.*;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.List;
 
 @Component
 public class TestDataLoader implements CommandLineRunner {
 
-    private final ProfileRepository profileRepository;
-    private final ProfilePrefsRepository profilePrefsRepository;
-    private final NotificationSettingsRepository notificationSettingsRepository;
-    private final ProfileStatsRepository profileStatsRepository;
-    private final ProfileLinkRepository profileLinkRepository;
-    private final ProfileFeaturedItemRepository profileFeaturedItemRepository;
+  private final ProfileRepository profileRepository;
+  private final ProfilePrefsRepository profilePrefsRepository;
+  private final NotificationSettingsRepository notificationSettingsRepository;
+  private final ProfileStatsRepository profileStatsRepository;
+  private final ProfileLinkRepository profileLinkRepository;
+  private final ProfileFeaturedItemRepository profileFeaturedItemRepository;
 
-    public TestDataLoader(ProfileRepository profileRepository,
-                          ProfilePrefsRepository profilePrefsRepository,
-                          NotificationSettingsRepository notificationSettingsRepository,
-                          ProfileStatsRepository profileStatsRepository,
-                          ProfileLinkRepository profileLinkRepository,
-                          ProfileFeaturedItemRepository profileFeaturedItemRepository) {
-        this.profileRepository = profileRepository;
-        this.profilePrefsRepository = profilePrefsRepository;
-        this.notificationSettingsRepository = notificationSettingsRepository;
-        this.profileStatsRepository = profileStatsRepository;
-        this.profileLinkRepository = profileLinkRepository;
-        this.profileFeaturedItemRepository = profileFeaturedItemRepository;
+  // NEW: cars repos
+  private final BrandRepository brandRepository;
+  private final SeriesRepository seriesRepository;
+  private final TagRepository tagRepository;
+  private final ListingRepository listingRepository;
+  private final ListingImageRepository listingImageRepository;
+  private final ListingTagRepository listingTagRepository;
+
+  public TestDataLoader(ProfileRepository profileRepository,
+                        ProfilePrefsRepository profilePrefsRepository,
+                        NotificationSettingsRepository notificationSettingsRepository,
+                        ProfileStatsRepository profileStatsRepository,
+                        ProfileLinkRepository profileLinkRepository,
+                        ProfileFeaturedItemRepository profileFeaturedItemRepository,
+                        BrandRepository brandRepository,
+                        SeriesRepository seriesRepository,
+                        TagRepository tagRepository,
+                        ListingRepository listingRepository,
+                        ListingImageRepository listingImageRepository,
+                        ListingTagRepository listingTagRepository) {
+    this.profileRepository = profileRepository;
+    this.profilePrefsRepository = profilePrefsRepository;
+    this.notificationSettingsRepository = notificationSettingsRepository;
+    this.profileStatsRepository = profileStatsRepository;
+    this.profileLinkRepository = profileLinkRepository;
+    this.profileFeaturedItemRepository = profileFeaturedItemRepository;
+    this.brandRepository = brandRepository;
+    this.seriesRepository = seriesRepository;
+    this.tagRepository = tagRepository;
+    this.listingRepository = listingRepository;
+    this.listingImageRepository = listingImageRepository;
+    this.listingTagRepository = listingTagRepository;
+  }
+
+  @Override
+  public void run(String... args) {
+    seedProfilesIfEmpty();
+    seedCarsIfEmpty();
+  }
+
+  private void seedProfilesIfEmpty() {
+    if (profileRepository.count() > 0) return;
+
+    for (long i = 1; i <= 5; i++) {
+      Profile profile = profileRepository.save(Profile.builder()
+          .userId(i)
+          .username("user" + i)
+          .displayName("User " + i)
+          .bio("Bio for user " + i)
+          .avatarUrl("https://example.com/avatar" + i + ".png")
+          .bannerUrl("https://example.com/banner" + i + ".png")
+          .location("City " + i)
+          .websiteUrl("https://example.com/user" + i)
+          .language("en")
+          .isVerified(i % 2 == 0)
+          .isPublic(true)
+          .build());
+
+      profilePrefsRepository.save(ProfilePrefs.builder()
+          .profileId(profile.getId())
+          .showEmail(i % 2 == 0)
+          .showLocation(true)
+          .showLinks(true)
+          .searchable(true)
+          .allowDm(true)
+          .showCollection(true)
+          .showListings(true)
+          .build());
+
+      notificationSettingsRepository.save(NotificationSettings.builder()
+          .profileId(profile.getId())
+          .emailGeneral(true)
+          .emailMessage(true)
+          .emailFavorite(true)
+          .emailListingActivity(true)
+          .pushGeneral(true)
+          .digestFrequency("WEEKLY")
+          .build());
+
+      profileStatsRepository.save(ProfileStats.builder()
+          .profileId(profile.getId())
+          .itemsCount(5)
+          .listingsActiveCount(2)
+          .favoritesCount(10)
+          .followersCount(3)
+          .responseRate((short) 90)
+          .lastActiveAt(Instant.now())
+          .build());
+
+      profileLinkRepository.save(ProfileLink.builder()
+          .profileId(profile.getId())
+          .type(ProfileLinkType.INSTAGRAM)
+          .label("IG " + i)
+          .url("https://instagram.com/user" + i)
+          .idx(0)
+          .isPublic(true)
+          .build());
+
+      profileFeaturedItemRepository.save(ProfileFeaturedItem.builder()
+          .id(new FeaturedItemId(profile.getId(), i))
+          .idx(0)
+          .build());
+    }
+  }
+
+  private void seedCarsIfEmpty() {
+    // --- brands / series / tags ---
+    if (brandRepository.count() == 0) {
+      var hw = brandRepository.save(Brand.builder().name("Hot Wheels").slug("hot-wheels").country("USA").build());
+      var tw = brandRepository.save(Brand.builder().name("Tarmac Works").slug("tarmac-works").country("Hong Kong").build());
+
+      seriesRepository.save(Series.builder().brandId(hw.getId()).name("Fast & Furious").slug("fast-and-furious").build());
+      seriesRepository.save(Series.builder().brandId(tw.getId()).name("Le Mans").slug("le-mans").build());
     }
 
-    @Override
-    public void run(String... args) {
-        if (profileRepository.count() > 0) {
-            return;
-        }
-
-        for (long i = 1; i <= 5; i++) {
-            Profile profile = profileRepository.save(Profile.builder()
-                    .userId(i)
-                    .username("user" + i)
-                    .displayName("User " + i)
-                    .bio("Bio for user " + i)
-                    .avatarUrl("https://example.com/avatar" + i + ".png")
-                    .bannerUrl("https://example.com/banner" + i + ".png")
-                    .location("City " + i)
-                    .websiteUrl("https://example.com/user" + i)
-                    .language("en")
-                    .isVerified(i % 2 == 0)
-                    .isPublic(true)
-                    .build());
-
-            profilePrefsRepository.save(ProfilePrefs.builder()
-                    .profileId(profile.getId())
-                    .showEmail(i % 2 == 0)
-                    .showLocation(true)
-                    .showLinks(true)
-                    .searchable(true)
-                    .allowDm(true)
-                    .showCollection(true)
-                    .showListings(true)
-                    .build());
-
-            notificationSettingsRepository.save(NotificationSettings.builder()
-                    .profileId(profile.getId())
-                    .emailGeneral(true)
-                    .emailMessage(true)
-                    .emailFavorite(true)
-                    .emailListingActivity(true)
-                    .pushGeneral(true)
-                    .digestFrequency("WEEKLY")
-                    .build());
-
-            profileStatsRepository.save(ProfileStats.builder()
-                    .profileId(profile.getId())
-                    .itemsCount(5)
-                    .listingsActiveCount(2)
-                    .favoritesCount(10)
-                    .followersCount(3)
-                    .responseRate((short) 90)
-                    .lastActiveAt(Instant.now())
-                    .build());
-
-            profileLinkRepository.save(ProfileLink.builder()
-                    .profileId(profile.getId())
-                    .type(ProfileLinkType.INSTAGRAM)
-                    .label("IG " + i)
-                    .url("https://instagram.com/user" + i)
-                    .idx(0)
-                    .isPublic(true)
-                    .build());
-
-            profileFeaturedItemRepository.save(ProfileFeaturedItem.builder()
-                    .id(new FeaturedItemId(profile.getId(), i))
-                    .idx(0)
-                    .build());
-        }
+    if (tagRepository.count() == 0) {
+      tagRepository.save(Tag.builder().name("JDM").slug("jdm").build());
+      tagRepository.save(Tag.builder().name("Movie Car").slug("movie-car").build());
+      tagRepository.save(Tag.builder().name("F1").slug("f1").build());
     }
+
+    // --- listings (örnek 3 adet) ---
+    if (listingRepository.count() == 0) {
+      var brands = brandRepository.findAll();
+      var series = seriesRepository.findAll();
+      Long brandId = brands.isEmpty() ? null : brands.get(0).getId();
+      Long seriesId = series.isEmpty() ? null : series.get(0).getId();
+
+      for (long i = 1; i <= 3; i++) {
+        var l = Listing.builder()
+            .sellerUserId(i) // user i
+            .title("Sample Listing " + i)
+            .description("Demo description " + i)
+            .brandId(brandId)
+            .seriesId(seriesId)
+            .modelName("Nissan Skyline GT-R R34")
+            .scale("1:64")
+            .modelYear((short)(1998 + i))
+            .condition(Condition.MINT)
+            .limitedEdition(i != 2) // 1 ve 3 true
+            .theme("JDM")
+            .countryOfOrigin("Japan")
+            .type(i == 3 ? ListingType.TRADE : ListingType.SALE)
+            .price(i == 3 ? null : new BigDecimal("199.99"))
+            .currency(i == 3 ? null : "USD")
+            .location("Izmir, TR")
+            .status(ListingStatus.ACTIVE)
+            .isActive(Boolean.TRUE)
+            .build();
+
+        l = listingRepository.save(l);
+
+        // images
+        listingImageRepository.saveAll(List.of(
+            ListingImage.builder().listingId(l.getId()).url("https://picsum.photos/seed/" + i + "/800/600").idx(0).build(),
+            ListingImage.builder().listingId(l.getId()).url("https://picsum.photos/seed/" + i + "b/800/600").idx(1).build()
+        ));
+
+        // tags: JDM + (Movie Car or F1)
+        var allTags = tagRepository.findAll();
+        var jdm = allTags.stream().filter(t -> "jdm".equalsIgnoreCase(t.getSlug())).findFirst().orElse(null);
+        var movie = allTags.stream().filter(t -> "movie-car".equalsIgnoreCase(t.getSlug())).findFirst().orElse(null);
+        var f1 = allTags.stream().filter(t -> "f1".equalsIgnoreCase(t.getSlug())).findFirst().orElse(null);
+
+        if (jdm != null) listingTagRepository.save(new ListingTag(new ListingTagId(l.getId(), jdm.getId())));
+        if (i == 1 && movie != null) listingTagRepository.save(new ListingTag(new ListingTagId(l.getId(), movie.getId())));
+        if (i == 2 && f1 != null) listingTagRepository.save(new ListingTag(new ListingTagId(l.getId(), f1.getId())));
+      }
+    }
+  }
 }
+

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/cars/ListingController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/cars/ListingController.java
@@ -38,8 +38,8 @@ public class ListingController {
       @RequestParam(required = false) String type,
       @RequestParam(required = false) String status,
       @RequestParam(required = false) String location,
-      @RequestParam(required = false) Short yearFrom,
-      @RequestParam(required = false) Short yearTo,
+      @RequestParam(required = false) Short modelYearFrom,
+      @RequestParam(required = false) Short modelYearTo,
       @RequestParam(required = false) BigDecimal priceMin,
       @RequestParam(required = false) BigDecimal priceMax,
       @RequestParam(defaultValue = "0") Integer page,
@@ -59,8 +59,8 @@ public class ListingController {
         .type(type)
         .status(status)
         .location(location)
-        .yearFrom(yearFrom)
-        .yearTo(yearTo)
+        .modelYearFrom(modelYearFrom)
+        .modelYearTo(modelYearTo)
         .priceMin(priceMin)
         .priceMax(priceMax)
         .page(page)

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingCreateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingCreateRequest.java
@@ -28,7 +28,7 @@ public class ListingCreateRequest {
   @Size(max=16)
   private String scale;           // "1:64" gibi
 
-  private Short year;
+  private Short modelYear;
 
   @Size(max=24)
   private String condition;       // "NEW","MINT","USED","CUSTOM" (enum-like string)

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingFilterRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingFilterRequest.java
@@ -27,8 +27,8 @@ public class ListingFilterRequest {
 
   private String location;         // free-text
 
-  private Short yearFrom;
-  private Short yearTo;
+  private Short modelYearFrom;
+  private Short modelYearTo;
 
   private BigDecimal priceMin;
   private BigDecimal priceMax;
@@ -40,7 +40,7 @@ public class ListingFilterRequest {
   @Builder.Default
   private Integer size = 20;
 
-  // createdAt, price, year
+  // createdAt, price, modelYear
   @Builder.Default
   private String sortBy = "createdAt";
 

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingResponseDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingResponseDto.java
@@ -24,7 +24,7 @@ public class ListingResponseDto {
   private String seriesName;   // opsiyonel
   private String modelName;
   private String scale;
-  private Short year;
+  private Short modelYear;
   private String condition;
   private Boolean limitedEdition;
   private String theme;

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingUpdateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingUpdateRequest.java
@@ -24,7 +24,7 @@ public class ListingUpdateRequest {
   @Size(max=16)
   private String scale;
 
-  private Short year;
+  private Short modelYear;
 
   @Size(max=24)
   private String condition;

--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Listing.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Listing.java
@@ -48,8 +48,8 @@ public class Listing extends BaseTime {
   @Column(length=16)
   private String scale;
 
-  @Column(name="year_made")
-  private Short year;
+  @Column(name="model_year")
+  private Short modelYear;
 
   @Enumerated(EnumType.STRING)
   @Column(length=24)

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingQueryRepositoryImpl.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/cars/ListingQueryRepositoryImpl.java
@@ -45,16 +45,16 @@ public class ListingQueryRepositoryImpl implements ListingQueryRepository {
     if (f.getLimitedEdition() != null) ps.add(cb.equal(root.get("limitedEdition"), f.getLimitedEdition()));
     if (f.getType() != null && !f.getType().isBlank()) ps.add(cb.equal(root.get("type"), ListingType.valueOf(f.getType().toUpperCase())));
     if (f.getLocation() != null && !f.getLocation().isBlank()) ps.add(cb.like(cb.lower(root.get("location")), "%" + f.getLocation().toLowerCase() + "%"));
-    if (f.getYearFrom() != null) ps.add(cb.greaterThanOrEqualTo(root.get("year"), f.getYearFrom()));
-    if (f.getYearTo() != null) ps.add(cb.lessThanOrEqualTo(root.get("year"), f.getYearTo()));
+    if (f.getModelYearFrom() != null) ps.add(cb.greaterThanOrEqualTo(root.get("modelYear"), f.getModelYearFrom()));
+    if (f.getModelYearTo() != null) ps.add(cb.lessThanOrEqualTo(root.get("modelYear"), f.getModelYearTo()));
     if (f.getPriceMin() != null) ps.add(cb.greaterThanOrEqualTo(root.get("price"), f.getPriceMin()));
     if (f.getPriceMax() != null) ps.add(cb.lessThanOrEqualTo(root.get("price"), f.getPriceMax()));
 
     cq.where(ps.toArray(Predicate[]::new));
 
     Path<?> sortPath = switch (f.getSortBy()) {
-      case "price" -> root.get("price");
-      case "year"  -> root.get("year");
+      case "price"     -> root.get("price");
+      case "modelYear" -> root.get("modelYear");
       default -> root.get("createdAt");
     };
     cq.orderBy("ASC".equalsIgnoreCase(f.getSortDir()) ? cb.asc(sortPath) : cb.desc(sortPath));


### PR DESCRIPTION
## Summary
- rename listing `year` field to `modelYear` across entity, DTOs, filters, queries and controller
- add demo car brand/series/tag/listing seeding to TestDataLoader

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a75bf8d944832ebd832526d94c82ed