### PR TITLE
Rename Car year field to avoid H2 reserved keyword

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/model/cars/Car.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/cars/Car.java
@@ -1,5 +1,6 @@
 package com.api.garagemint.garagemintapi.model.cars;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,7 +26,8 @@ class Car {
     private UUID id;
     private String make;
     private String model;
-    private int year;
+    @Column(name = "model_year")
+    private int modelYear;
     private String color;
     private BigDecimal estimatedValue;
     @ElementCollection


### PR DESCRIPTION
## Summary
- rename `year` field in `Car` entity to `modelYear`
- map the property to `model_year` column to avoid reserved keyword issues

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763c7fde4832eb8988a0c2f260293