### PR TITLE
Add MapStruct enum imports to fix mapper compilation

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/mapper/cars/ListingMapper.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/mapper/cars/ListingMapper.java
@@ -9,7 +9,8 @@ import java.util.List;
 
 @Mapper(
     componentModel = "spring",
-    unmappedTargetPolicy = ReportingPolicy.IGNORE
+    unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    imports = {ListingType.class, Condition.class, ListingStatus.class}
 )
 public interface ListingMapper {
 


### PR DESCRIPTION
## Summary
- import enum types in `ListingMapper` to allow MapStruct to compile expressions referencing `ListingType`, `Condition`, and `ListingStatus`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a766375e88832eaa0d0a5c6032cec9