### PR TITLE
Add user listings to profile responses

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileOwnerDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileOwnerDto.java
@@ -3,6 +3,7 @@ package com.api.garagemint.garagemintapi.dto.profile;
 import lombok.*;
 import java.time.Instant;
 import java.util.List;
+import com.api.garagemint.garagemintapi.dto.cars.ListingResponseDto;
 
 @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 public class ProfileOwnerDto {
@@ -25,4 +26,5 @@ public class ProfileOwnerDto {
   private ProfilePrefsDto prefs;
   private NotificationSettingsDto notificationSettings;
   private ProfileStatsDto stats;
+  private List<ListingResponseDto> listings;
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePublicDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePublicDto.java
@@ -3,6 +3,7 @@ package com.api.garagemint.garagemintapi.dto.profile;
 import lombok.*;
 import java.time.Instant;
 import java.util.List;
+import com.api.garagemint.garagemintapi.dto.cars.ListingResponseDto;
 
 @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 public class ProfilePublicDto {
@@ -23,4 +24,5 @@ public class ProfilePublicDto {
 
   private List<ProfileLinkDto> links;   // public görünenler
   private ProfileStatsDto stats;        // sayaçlar
+  private List<ListingResponseDto> listings;
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/mapper/profile/ProfileMapper.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/mapper/profile/ProfileMapper.java
@@ -12,12 +12,14 @@ public interface ProfileMapper {
   // Entity -> DTO
   @Mapping(target = "links", ignore = true)
   @Mapping(target = "stats", ignore = true)
+  @Mapping(target = "listings", ignore = true)
   ProfilePublicDto toPublicDto(Profile profile);
 
   @Mapping(target = "links", ignore = true)
   @Mapping(target = "prefs", ignore = true)
   @Mapping(target = "notificationSettings", ignore = true)
   @Mapping(target = "stats", ignore = true)
+  @Mapping(target = "listings", ignore = true)
   ProfileOwnerDto toOwnerDto(Profile profile);
 
   // Links

--- a/src/main/java/com/api/garagemint/garagemintapi/service/cars/ListingService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/cars/ListingService.java
@@ -110,6 +110,15 @@ public class ListingService {
         .stream().map(l -> assembleResponse(l.getId())).toList();
   }
 
+  @Transactional(readOnly = true)
+  public List<ListingResponseDto> listPublicActive(Long sellerUserId) {
+    return listingRepo.findBySellerUserIdAndStatus(sellerUserId, ListingStatus.ACTIVE)
+        .stream()
+        .filter(l -> Boolean.TRUE.equals(l.getIsActive()))
+        .map(l -> assembleResponse(l.getId()))
+        .toList();
+  }
+
   /* =============== UPDATE =============== */
 
   @Transactional

--- a/src/main/java/com/api/garagemint/garagemintapi/service/profile/ProfileService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/profile/ProfileService.java
@@ -7,6 +7,7 @@ import com.api.garagemint.garagemintapi.repository.*;
 import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
 import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
 import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import com.api.garagemint.garagemintapi.service.cars.ListingService;
 import com.api.garagemint.garagemintapi.service.profile.util.ReservedUsernames;
 import com.api.garagemint.garagemintapi.service.profile.validator.LinkValidator;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class ProfileService {
   private final NotificationSettingsRepository notifRepo;
   private final ProfileStatsRepository statsRepo;
   private final ProfileMapper mapper;
+  private final ListingService listingService;
 
   /* -------------------- PUBLIC -------------------- */
 
@@ -43,6 +45,7 @@ public class ProfileService {
       dto.setWebsiteUrl(null);
       dto.setLinks(List.of());
       dto.setStats(null);
+      dto.setListings(List.of());
       return dto;
     }
 
@@ -52,6 +55,9 @@ public class ProfileService {
     var stats = statsRepo.findById(p.getId())
         .orElseGet(() -> ProfileStats.builder().profileId(p.getId()).build());
     dto.setStats(mapper.toDto(stats));
+
+    var listings = listingService.listPublicActive(p.getUserId());
+    dto.setListings(listings);
 
     return dto;
   }
@@ -131,6 +137,9 @@ public class ProfileService {
 
     var stats = statsRepo.findById(p.getId()).orElseGet(() -> defaultsStats(p));
     ownerDto.setStats(mapper.toDto(stats));
+
+    var listings = listingService.listMyActive(p.getUserId());
+    ownerDto.setListings(listings);
 
     return ownerDto;
   }


### PR DESCRIPTION
## Summary
- include vehicle listings in profile owner and public responses
- add profile mapper support for listings
- expose listing service method to list public active listings
- populate listings in profile service

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ed472884832ea62478296d37bd23