### PR TITLE
Add auction domain and API

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/config/AppConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/AppConfig.java
@@ -1,0 +1,8 @@
+package com.api.garagemint.garagemintapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class AppConfig {}

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/auction/AuctionController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/auction/AuctionController.java
@@ -1,0 +1,51 @@
+package com.api.garagemint.garagemintapi.controller.auction;
+
+import com.api.garagemint.garagemintapi.dto.auction.*;
+import com.api.garagemint.garagemintapi.service.auction.AuctionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(value="/api/v1/auctions", produces="application/json")
+@RequiredArgsConstructor
+public class AuctionController {
+
+  private final AuctionService auctionService;
+
+  // ---- Public ----
+  @GetMapping("/{id}")
+  public AuctionResponseDto get(@PathVariable Long id) {
+    return auctionService.getAuction(id);
+  }
+
+  @GetMapping
+  public List<AuctionListItemDto> listActive() {
+    return auctionService.listActiveAuctions();
+  }
+
+  @GetMapping("/{id}/bids")
+  public List<BidResponseDto> bids(@PathVariable Long id) {
+    return auctionService.getBids(id);
+  }
+
+  // ---- Seller (mock userId = 1L) ----
+  @PostMapping
+  public AuctionResponseDto create(@Valid @RequestBody AuctionCreateRequest req) {
+    return auctionService.createAuction(1L, req);
+  }
+
+  @PostMapping("/{id}/cancel")
+  public AuctionResponseDto cancel(@PathVariable Long id) {
+    return auctionService.cancelAuction(1L, id);
+  }
+
+  // ---- Bidding (mock userId = 2L) ----
+  // Not: Gerçekte bidder userId, SecurityContext'ten gelecek
+  @PostMapping("/{id}/bids")
+  public BidResponseDto bid(@PathVariable Long id, @Valid @RequestBody BidCreateRequest req) {
+    return auctionService.placeBid(2L, id, req);
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/auction/AuctionCreateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/auction/AuctionCreateRequest.java
@@ -1,0 +1,21 @@
+package com.api.garagemint.garagemintapi.dto.auction;
+
+import lombok.*;
+import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AuctionCreateRequest {
+  private Long listingId; // opsiyonel
+
+  @NotNull @DecimalMin("0.01")
+  private BigDecimal startPrice;
+
+  /** null ise "now" ile başlat; yoksa ileri tarih olmalı */
+  private Instant startsAt;
+
+  /** zorunlu; (startsAt or now) + [1..15] gün aralığında olmalı */
+  @NotNull
+  private Instant endsAt;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/auction/AuctionListItemDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/auction/AuctionListItemDto.java
@@ -1,0 +1,17 @@
+package com.api.garagemint.garagemintapi.dto.auction;
+
+import com.api.garagemint.garagemintapi.model.auction.AuctionStatus;
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AuctionListItemDto {
+  private Long id;
+  private Long listingId;
+  private BigDecimal startPrice;
+  private BigDecimal highestBidAmount;
+  private String currency;
+  private AuctionStatus status;
+  private Instant endsAt;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/auction/AuctionResponseDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/auction/AuctionResponseDto.java
@@ -1,0 +1,22 @@
+package com.api.garagemint.garagemintapi.dto.auction;
+
+import com.api.garagemint.garagemintapi.model.auction.AuctionStatus;
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class AuctionResponseDto {
+  private Long id;
+  private Long sellerUserId;
+  private Long listingId;
+  private BigDecimal startPrice;
+  private String currency;
+  private Instant startsAt;
+  private Instant endsAt;
+  private AuctionStatus status;
+  private BigDecimal highestBidAmount;
+  private Long highestBidUserId;
+  private Instant createdAt;
+  private Instant updatedAt;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/auction/BidCreateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/auction/BidCreateRequest.java
@@ -1,0 +1,11 @@
+package com.api.garagemint.garagemintapi.dto.auction;
+
+import lombok.*;
+import jakarta.validation.constraints.*;
+import java.math.BigDecimal;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class BidCreateRequest {
+  @NotNull @DecimalMin("0.01")
+  private BigDecimal amount;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/auction/BidResponseDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/auction/BidResponseDto.java
@@ -1,0 +1,14 @@
+package com.api.garagemint.garagemintapi.dto.auction;
+
+import lombok.*;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class BidResponseDto {
+  private Long id;
+  private Long auctionId;
+  private Long bidderUserId;
+  private BigDecimal amount;
+  private Instant createdAt;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/mapper/auction/AuctionMapper.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/mapper/auction/AuctionMapper.java
@@ -1,0 +1,17 @@
+package com.api.garagemint.garagemintapi.mapper.auction;
+
+import com.api.garagemint.garagemintapi.dto.auction.*;
+import com.api.garagemint.garagemintapi.model.auction.*;
+import org.mapstruct.*;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface AuctionMapper {
+
+  AuctionResponseDto toDto(Auction a);
+
+  @Mapping(target = "auctionId", source = "auction.id")
+  BidResponseDto toDto(AuctionBid b);
+
+  @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+  void updateAuctionFromCreate(AuctionCreateRequest req, @MappingTarget Auction a);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/model/auction/Auction.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/auction/Auction.java
@@ -1,0 +1,65 @@
+package com.api.garagemint.garagemintapi.model.auction;
+
+import com.api.garagemint.garagemintapi.model.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+@Entity
+@Table(name = "auctions",
+  indexes = {
+    @Index(name="idx_auctions_status", columnList = "status"),
+    @Index(name="idx_auctions_seller", columnList = "seller_user_id"),
+    @Index(name="idx_auctions_starts_at", columnList = "starts_at"),
+    @Index(name="idx_auctions_ends_at", columnList = "ends_at")
+  }
+)
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class Auction extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  /** Mezatı açan kullanıcının user id'si */
+  @Column(name="seller_user_id", nullable=false)
+  private Long sellerUserId;
+
+  /** Opsiyonel: İlan referansı (ayrı domain, fiyat/durum ayrıdır) */
+  @Column(name="listing_id")
+  private Long listingId;
+
+  /** Başlangıç fiyatı (TRY) */
+  @Column(name="start_price", nullable=false, precision=18, scale=2)
+  private BigDecimal startPrice;
+
+  /** TRY harici destek şimdilik yok; ileride çoklu currency için genişletilecek */
+  @Column(name="currency", nullable=false, length=3)
+  @Builder.Default
+  private String currency = "TRY";
+
+  /** Zaman penceresi */
+  @Column(name="starts_at", nullable=false)
+  private Instant startsAt;
+
+  @Column(name="ends_at", nullable=false)
+  private Instant endsAt;
+
+  /** Durum makinesi */
+  @Enumerated(EnumType.STRING)
+  @Column(name="status", nullable=false, length=16)
+  @Builder.Default
+  private AuctionStatus status = AuctionStatus.SCHEDULED;
+
+  /** Hızlı listeleme için denormalize alanlar */
+  @Column(name="highest_bid_amount", precision=18, scale=2)
+  private BigDecimal highestBidAmount;
+
+  @Column(name="highest_bid_user_id")
+  private Long highestBidUserId;
+
+  /** Optimistic locking — eşzamanlı teklif yarışında güvenlik */
+  @Version
+  private Long version;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/model/auction/AuctionBid.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/auction/AuctionBid.java
@@ -1,0 +1,31 @@
+package com.api.garagemint.garagemintapi.model.auction;
+
+import com.api.garagemint.garagemintapi.model.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "auction_bids",
+  indexes = {
+    @Index(name="idx_bids_auction", columnList = "auction_id"),
+    @Index(name="idx_bids_bidder", columnList = "bidder_user_id")
+  }
+)
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class AuctionBid extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name="auction_id", nullable=false, foreignKey = @ForeignKey(name="fk_bid_auction"))
+  private Auction auction;
+
+  @Column(name="bidder_user_id", nullable=false)
+  private Long bidderUserId;
+
+  @Column(name="amount", nullable=false, precision=18, scale=2)
+  private BigDecimal amount;
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/model/auction/AuctionStatus.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/auction/AuctionStatus.java
@@ -1,0 +1,4 @@
+package com.api.garagemint.garagemintapi.model.auction;
+public enum AuctionStatus {
+  SCHEDULED, ACTIVE, ENDED, CANCELLED
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/auction/AuctionBidRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/auction/AuctionBidRepository.java
@@ -1,0 +1,10 @@
+package com.api.garagemint.garagemintapi.repository.auction;
+
+import com.api.garagemint.garagemintapi.model.auction.AuctionBid;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AuctionBidRepository extends JpaRepository<AuctionBid, Long> {
+  List<AuctionBid> findByAuction_IdOrderByCreatedAtAsc(Long auctionId);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/auction/AuctionRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/auction/AuctionRepository.java
@@ -1,0 +1,24 @@
+package com.api.garagemint.garagemintapi.repository.auction;
+
+import com.api.garagemint.garagemintapi.model.auction.Auction;
+import com.api.garagemint.garagemintapi.model.auction.AuctionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
+
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
+import java.time.Instant;
+import java.util.List;
+
+public interface AuctionRepository extends JpaRepository<Auction, Long> {
+
+  List<Auction> findByStatusAndEndsAtBefore(AuctionStatus status, Instant now);
+
+  List<Auction> findByStatus(AuctionStatus status);
+
+  /** Teklif anında optimistic lock yeterli; yine de isteğe bağlı PESSIMISTIC_WRITE desteklemek için aşağıdaki method eklenebilir */
+  @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+  @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+  Auction findWithOptimisticLockingById(Long id);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/auction/AuctionScheduler.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/auction/AuctionScheduler.java
@@ -1,0 +1,18 @@
+package com.api.garagemint.garagemintapi.service.auction;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuctionScheduler {
+
+  private final AuctionService auctionService;
+
+  /** Her dakikada bir, süresi dolan mezatları kapat */
+  @Scheduled(fixedDelay = 60_000)
+  public void closeExpired() {
+    auctionService.closeExpiredAuctions();
+  }
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/auction/AuctionService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/auction/AuctionService.java
@@ -1,0 +1,172 @@
+package com.api.garagemint.garagemintapi.service.auction;
+
+import com.api.garagemint.garagemintapi.dto.auction.*;
+import com.api.garagemint.garagemintapi.mapper.auction.AuctionMapper;
+import com.api.garagemint.garagemintapi.model.auction.*;
+import com.api.garagemint.garagemintapi.repository.auction.AuctionBidRepository;
+import com.api.garagemint.garagemintapi.repository.auction.AuctionRepository;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import com.api.garagemint.garagemintapi.service.notification.EmailService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AuctionService {
+
+  private static final BigDecimal MIN_INCREMENT = new BigDecimal("10.00"); // 10 TL
+
+  private final AuctionRepository auctionRepo;
+  private final AuctionBidRepository bidRepo;
+  private final AuctionMapper mapper;
+  private final EmailService emailService;
+
+  /* ========= PUBLIC ========= */
+
+  @Transactional(readOnly = true)
+  public AuctionResponseDto getAuction(Long id) {
+    var a = auctionRepo.findById(id).orElseThrow(() -> new NotFoundException("Auction not found"));
+    return mapper.toDto(a);
+  }
+
+  @Transactional(readOnly = true)
+  public List<AuctionListItemDto> listActiveAuctions() {
+    return auctionRepo.findByStatus(AuctionStatus.ACTIVE).stream()
+        .map(a -> AuctionListItemDto.builder()
+            .id(a.getId())
+            .listingId(a.getListingId())
+            .startPrice(a.getStartPrice())
+            .highestBidAmount(a.getHighestBidAmount())
+            .currency(a.getCurrency())
+            .status(a.getStatus())
+            .endsAt(a.getEndsAt())
+            .build())
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public List<BidResponseDto> getBids(Long auctionId) {
+    var a = auctionRepo.findById(auctionId).orElseThrow(() -> new NotFoundException("Auction not found"));
+    return bidRepo.findByAuction_IdOrderByCreatedAtAsc(a.getId()).stream()
+        .map(mapper::toDto)
+        .toList();
+  }
+
+  /* ========= SELLER ========= */
+
+  @Transactional
+  public AuctionResponseDto createAuction(Long sellerUserId, AuctionCreateRequest req) {
+    if (sellerUserId == null) throw new ValidationException("sellerUserId is required");
+    if (req == null) throw new ValidationException("request body is required");
+
+    var now = Instant.now();
+    var startsAt = (req.getStartsAt() == null) ? now : req.getStartsAt();
+    if (startsAt.isBefore(now.minusSeconds(5))) {
+      throw new ValidationException("startsAt cannot be in the past");
+    }
+    if (req.getEndsAt().isBefore(startsAt)) {
+      throw new ValidationException("endsAt must be after startsAt");
+    }
+    var dur = Duration.between(startsAt, req.getEndsAt()).toDays();
+    if (dur < 1 || dur > 15) {
+      throw new BusinessRuleException("Auction duration must be between 1 and 15 days");
+    }
+
+    var a = Auction.builder()
+        .sellerUserId(sellerUserId)
+        .listingId(req.getListingId())
+        .startPrice(req.getStartPrice())
+        .currency("TRY")
+        .startsAt(startsAt)
+        .endsAt(req.getEndsAt())
+        .status(startsAt.isAfter(now) ? AuctionStatus.SCHEDULED : AuctionStatus.ACTIVE)
+        .highestBidAmount(null)
+        .highestBidUserId(null)
+        .build();
+
+    a = auctionRepo.save(a);
+    return mapper.toDto(a);
+  }
+
+  @Transactional
+  public AuctionResponseDto cancelAuction(Long sellerUserId, Long auctionId) {
+    var a = auctionRepo.findById(auctionId).orElseThrow(() -> new NotFoundException("Auction not found"));
+    if (!a.getSellerUserId().equals(sellerUserId)) throw new BusinessRuleException("Forbidden");
+    if (a.getStatus() == AuctionStatus.ENDED) throw new BusinessRuleException("Auction already ended");
+    // Tercihen: ilk bid gelmeden iptal; basitleştirelim:
+    if (a.getStatus() == AuctionStatus.ACTIVE && a.getHighestBidAmount() != null) {
+      throw new BusinessRuleException("Cannot cancel after first bid");
+    }
+    a.setStatus(AuctionStatus.CANCELLED);
+    auctionRepo.save(a);
+    return mapper.toDto(a);
+  }
+
+  /* ========= BIDDING ========= */
+
+  @Transactional
+  public BidResponseDto placeBid(Long bidderUserId, Long auctionId, BidCreateRequest req) {
+    if (bidderUserId == null) throw new ValidationException("bidderUserId is required");
+    if (req == null) throw new ValidationException("request body is required");
+
+    // Lock with optimistic versioning (force increment) to avoid race
+    var a = auctionRepo.findWithOptimisticLockingById(auctionId);
+    var now = Instant.now();
+
+    if (a.getStatus() == AuctionStatus.SCHEDULED && now.isAfter(a.getStartsAt())) {
+      a.setStatus(AuctionStatus.ACTIVE);
+    }
+    if (a.getStatus() != AuctionStatus.ACTIVE) throw new BusinessRuleException("Auction not active");
+    if (now.isAfter(a.getEndsAt())) throw new BusinessRuleException("Auction already ended");
+    if (a.getSellerUserId().equals(bidderUserId)) throw new BusinessRuleException("Seller cannot bid");
+
+    var minRequired = (a.getHighestBidAmount() == null)
+        ? a.getStartPrice()
+        : a.getHighestBidAmount().add(MIN_INCREMENT);
+
+    if (req.getAmount().compareTo(minRequired) < 0) {
+      throw new BusinessRuleException("Bid must be >= " + minRequired);
+    }
+
+    var bid = AuctionBid.builder()
+        .auction(a)
+        .bidderUserId(bidderUserId)
+        .amount(req.getAmount())
+        .build();
+    bid = bidRepo.save(bid);
+
+    a.setHighestBidAmount(req.getAmount());
+    a.setHighestBidUserId(bidderUserId);
+    auctionRepo.save(a);
+
+    return mapper.toDto(bid);
+  }
+
+  /* ========= CLOSURE / SCHEDULER ========= */
+
+  @Transactional
+  public void closeExpiredAuctions() {
+    var now = Instant.now();
+    var list = auctionRepo.findByStatusAndEndsAtBefore(AuctionStatus.ACTIVE, now);
+    for (var a : list) {
+      a.setStatus(AuctionStatus.ENDED);
+      auctionRepo.save(a);
+
+      // Email notifications
+      if (a.getHighestBidUserId() != null) {
+        emailService.sendAuctionWonEmail(a.getHighestBidUserId(), a.getId(), a.getHighestBidAmount());
+      }
+      emailService.sendAuctionClosedEmailToSeller(a.getSellerUserId(), a.getId(), a.getHighestBidAmount(), a.getHighestBidUserId());
+    }
+  }
+
+  /* ========= HELPERS ========= */
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/notification/EmailService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/notification/EmailService.java
@@ -1,0 +1,8 @@
+package com.api.garagemint.garagemintapi.service.notification;
+
+import java.math.BigDecimal;
+
+public interface EmailService {
+  void sendAuctionWonEmail(Long winnerUserId, Long auctionId, BigDecimal amount);
+  void sendAuctionClosedEmailToSeller(Long sellerUserId, Long auctionId, BigDecimal highestAmount, Long winnerUserId);
+}

--- a/src/main/java/com/api/garagemint/garagemintapi/service/notification/FakeEmailService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/notification/FakeEmailService.java
@@ -1,0 +1,19 @@
+package com.api.garagemint.garagemintapi.service.notification;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@Slf4j
+public class FakeEmailService implements EmailService {
+  @Override
+  public void sendAuctionWonEmail(Long winnerUserId, Long auctionId, BigDecimal amount) {
+    log.info("[MAIL] Winner userId={} auctionId={} amount={}", winnerUserId, auctionId, amount);
+  }
+  @Override
+  public void sendAuctionClosedEmailToSeller(Long sellerUserId, Long auctionId, BigDecimal highestAmount, Long winnerUserId) {
+    log.info("[MAIL] Seller userId={} auctionId={} highest={} winner={}", sellerUserId, auctionId, highestAmount, winnerUserId);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce auction entities, DTOs, repositories and mapper
- add auction service with bid placement, closing scheduler and email notifications
- expose auction REST endpoints and enable scheduling

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b6064702a0832e84a47ff3f78ca1fc