### PR TITLE
feat(profile): add follow module

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
@@ -16,6 +16,21 @@ public class CorsConfig {
             .allowedOrigins("http://localhost:3000")
             .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
             .allowCredentials(true);
+
+        registry.addMapping("/api/v1/profiles/*/follow")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowCredentials(true);
+
+        registry.addMapping("/api/v1/profiles/*/followers")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowCredentials(true);
+
+        registry.addMapping("/api/v1/profiles/*/following")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowCredentials(true);
       }
     };
   }

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileController.java
@@ -19,8 +19,9 @@ public class ProfileController {
     // ---- Public Endpoints ----
 
     @GetMapping("/{username}")
-    public ProfilePublicDto getPublicProfile(@PathVariable String username) {
-        return profileService.getPublicProfileByUsername(username);
+    public ProfilePublicDto getPublicProfile(@PathVariable String username,
+                                             @RequestParam(name="viewerUserId", required=false) Long viewerUserId) {
+        return profileService.getPublicProfileByUsername(username, viewerUserId);
     }
 
     @GetMapping("/check-username")

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileFollowController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileFollowController.java
@@ -1,0 +1,42 @@
+package com.api.garagemint.garagemintapi.controller.profile;
+
+import com.api.garagemint.garagemintapi.dto.profile.FollowListResponse;
+import com.api.garagemint.garagemintapi.service.profile.ProfileFollowService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping(value="/api/v1/profiles", produces="application/json")
+@RequiredArgsConstructor
+public class ProfileFollowController {
+
+  private final ProfileFollowService followService;
+
+  // TODO: gerçek auth gelince meUserId SecurityContext'ten alınacak
+  private Long meUserId() { return 1L; }
+
+  @PostMapping("/{username}/follow")
+  public void follow(@PathVariable String username) {
+    followService.follow(meUserId(), username);
+  }
+
+  @DeleteMapping("/{username}/follow")
+  public void unfollow(@PathVariable String username) {
+    followService.unfollow(meUserId(), username);
+  }
+
+  @GetMapping("/{username}/followers")
+  public FollowListResponse followers(@PathVariable String username,
+                                      @RequestParam(defaultValue = "0") int page,
+                                      @RequestParam(defaultValue = "20") int size) {
+    return followService.listFollowers(username, page, size);
+  }
+
+  @GetMapping("/{username}/following")
+  public FollowListResponse following(@PathVariable String username,
+                                      @RequestParam(defaultValue = "0") int page,
+                                      @RequestParam(defaultValue = "20") int size) {
+    return followService.listFollowing(username, page, size);
+  }
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/FollowListResponse.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/FollowListResponse.java
@@ -1,0 +1,14 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+import java.util.List;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class FollowListResponse {
+  private List<FollowUserDto> items;
+  private int page;
+  private int size;
+  private long totalElements;
+  private int totalPages;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/FollowUserDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/FollowUserDto.java
@@ -1,0 +1,13 @@
+package com.api.garagemint.garagemintapi.dto.profile;
+
+import lombok.*;
+
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class FollowUserDto {
+  private Long id;            // profileId
+  private String username;
+  private String displayName;
+  private String avatarUrl;
+  private Boolean isVerified;
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileOwnerDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfileOwnerDto.java
@@ -26,5 +26,9 @@ public class ProfileOwnerDto {
   private ProfilePrefsDto prefs;
   private NotificationSettingsDto notificationSettings;
   private ProfileStatsDto stats;
+
+  private Integer followersCount;
+  private Integer followingCount;
+
   private List<ListingResponseDto> listings;
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePublicDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/profile/ProfilePublicDto.java
@@ -25,4 +25,8 @@ public class ProfilePublicDto {
   private List<ProfileLinkDto> links;   // public görünenler
   private ProfileStatsDto stats;        // sayaçlar
   private List<ListingResponseDto> listings;
+
+  // viewer context (optional)
+  private Boolean isFollowing;     // viewer -> target
+  private Boolean isFollowedByMe;  // alias of isFollowing
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/mapper/profile/ProfileMapper.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/mapper/profile/ProfileMapper.java
@@ -13,6 +13,8 @@ public interface ProfileMapper {
   @Mapping(target = "links", ignore = true)
   @Mapping(target = "stats", ignore = true)
   @Mapping(target = "listings", ignore = true)
+  @Mapping(target = "isFollowing", ignore = true)
+  @Mapping(target = "isFollowedByMe", ignore = true)
   ProfilePublicDto toPublicDto(Profile profile);
 
   @Mapping(target = "links", ignore = true)
@@ -20,6 +22,8 @@ public interface ProfileMapper {
   @Mapping(target = "notificationSettings", ignore = true)
   @Mapping(target = "stats", ignore = true)
   @Mapping(target = "listings", ignore = true)
+  @Mapping(target = "followersCount", ignore = true)
+  @Mapping(target = "followingCount", ignore = true)
   ProfileOwnerDto toOwnerDto(Profile profile);
 
   // Links

--- a/src/main/java/com/api/garagemint/garagemintapi/model/profile/ProfileFollow.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/profile/ProfileFollow.java
@@ -1,0 +1,29 @@
+package com.api.garagemint.garagemintapi.model.profile;
+
+import com.api.garagemint.garagemintapi.model.common.BaseTime;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "profile_follows",
+    uniqueConstraints = @UniqueConstraint(name = "ux_follow_unique", columnNames = {"follower_profile_id","followed_profile_id"}),
+    indexes = {
+        @Index(name="idx_follow_follower", columnList = "follower_profile_id"),
+        @Index(name="idx_follow_followed", columnList = "followed_profile_id")
+    }
+)
+@Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
+public class ProfileFollow extends BaseTime {
+
+  @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name="follower_profile_id", nullable=false, foreignKey = @ForeignKey(name="fk_follow_follower"))
+  private Profile follower;   // takip eden
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name="followed_profile_id", nullable=false, foreignKey = @ForeignKey(name="fk_follow_followed"))
+  private Profile followed;   // takip edilen
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/profiles/ProfileFollowRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/profiles/ProfileFollowRepository.java
@@ -1,0 +1,20 @@
+package com.api.garagemint.garagemintapi.repository.profiles;
+
+import com.api.garagemint.garagemintapi.model.profile.ProfileFollow;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProfileFollowRepository extends JpaRepository<ProfileFollow, Long> {
+
+  boolean existsByFollower_IdAndFollowed_Id(Long followerProfileId, Long followedProfileId);
+
+  long countByFollowed_Id(Long followedProfileId); // followers
+  long countByFollower_Id(Long followerProfileId); // following
+
+  Page<ProfileFollow> findByFollowed_Id(Long followedProfileId, Pageable pageable); // followers list
+  Page<ProfileFollow> findByFollower_Id(Long followerProfileId, Pageable pageable); // following list
+
+  void deleteByFollower_IdAndFollowed_Id(Long followerProfileId, Long followedProfileId);
+}
+

--- a/src/main/java/com/api/garagemint/garagemintapi/service/profile/ProfileFollowService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/profile/ProfileFollowService.java
@@ -1,0 +1,141 @@
+package com.api.garagemint.garagemintapi.service.profile;
+
+import com.api.garagemint.garagemintapi.dto.profile.*;
+import com.api.garagemint.garagemintapi.model.profile.Profile;
+import com.api.garagemint.garagemintapi.model.profile.ProfileFollow;
+import com.api.garagemint.garagemintapi.repository.profiles.ProfileFollowRepository;
+import com.api.garagemint.garagemintapi.repository.profiles.ProfileRepository;
+import com.api.garagemint.garagemintapi.repository.profiles.ProfileStatsRepository;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
+import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileFollowService {
+
+  private final ProfileRepository profileRepo;
+  private final ProfileFollowRepository followRepo;
+  private final ProfileStatsRepository statsRepo;
+
+  private Profile loadByUsername(String username) {
+    if (username == null || username.isBlank()) throw new ValidationException("username is required");
+    return profileRepo.findByUsernameIgnoreCase(username)
+        .orElseThrow(() -> new NotFoundException("Profile not found"));
+  }
+
+  @Transactional
+  public void follow(Long meUserId, String targetUsername) {
+    var me = profileRepo.findByUserId(meUserId)
+        .orElseThrow(() -> new NotFoundException("My profile not found"));
+    var target = loadByUsername(targetUsername);
+
+    if (me.getId().equals(target.getId())) throw new BusinessRuleException("Cannot follow yourself");
+    if (followRepo.existsByFollower_IdAndFollowed_Id(me.getId(), target.getId())) return; // idempotent
+
+    followRepo.save(ProfileFollow.builder().follower(me).followed(target).build());
+
+    // sayaçlar — atomik tutmak için basit +1/-1; istekte aynı tx içinde
+    var targetStats = statsRepo.findById(target.getId()).orElse(null);
+    if (targetStats != null) {
+      targetStats.setFollowersCount((targetStats.getFollowersCount() == null ? 0 : targetStats.getFollowersCount()) + 1);
+      statsRepo.save(targetStats);
+    }
+    var meStats = statsRepo.findById(me.getId()).orElse(null);
+    if (meStats != null) {
+      Integer old = meStats.getFollowingCount() == null ? 0 : meStats.getFollowingCount();
+      meStats.setFollowingCount(old + 1);
+      statsRepo.save(meStats);
+    }
+  }
+
+  @Transactional
+  public void unfollow(Long meUserId, String targetUsername) {
+    var me = profileRepo.findByUserId(meUserId)
+        .orElseThrow(() -> new NotFoundException("My profile not found"));
+    var target = loadByUsername(targetUsername);
+
+    if (!followRepo.existsByFollower_IdAndFollowed_Id(me.getId(), target.getId())) return; // idempotent
+    followRepo.deleteByFollower_IdAndFollowed_Id(me.getId(), target.getId());
+
+    var targetStats = statsRepo.findById(target.getId()).orElse(null);
+    if (targetStats != null) {
+      int cur = targetStats.getFollowersCount() == null ? 0 : targetStats.getFollowersCount();
+      targetStats.setFollowersCount(Math.max(0, cur - 1));
+      statsRepo.save(targetStats);
+    }
+    var meStats = statsRepo.findById(me.getId()).orElse(null);
+    if (meStats != null) {
+      int cur = meStats.getFollowingCount() == null ? 0 : meStats.getFollowingCount();
+      meStats.setFollowingCount(Math.max(0, cur - 1));
+      statsRepo.save(meStats);
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public FollowListResponse listFollowers(String username, int page, int size) {
+    var target = loadByUsername(username);
+    var p = PageRequest.of(Math.max(0,page), Math.min(100, Math.max(1,size)), Sort.by(Sort.Direction.DESC, "createdAt"));
+    var pageRes = followRepo.findByFollowed_Id(target.getId(), p);
+
+    List<FollowUserDto> items = pageRes.getContent().stream().map(f -> {
+      var u = f.getFollower();
+      return FollowUserDto.builder()
+          .id(u.getId())
+          .username(u.getUsername())
+          .displayName(u.getDisplayName())
+          .avatarUrl(u.getAvatarUrl())
+          .isVerified(u.isVerified())
+          .build();
+    }).toList();
+
+    return FollowListResponse.builder()
+        .items(items)
+        .page(pageRes.getNumber())
+        .size(pageRes.getSize())
+        .totalElements(pageRes.getTotalElements())
+        .totalPages(pageRes.getTotalPages())
+        .build();
+  }
+
+  @Transactional(readOnly = true)
+  public FollowListResponse listFollowing(String username, int page, int size) {
+    var me = loadByUsername(username);
+    var p = PageRequest.of(Math.max(0,page), Math.min(100, Math.max(1,size)), Sort.by(Sort.Direction.DESC, "createdAt"));
+    var pageRes = followRepo.findByFollower_Id(me.getId(), p);
+
+    List<FollowUserDto> items = pageRes.getContent().stream().map(f -> {
+      var u = f.getFollowed();
+      return FollowUserDto.builder()
+          .id(u.getId())
+          .username(u.getUsername())
+          .displayName(u.getDisplayName())
+          .avatarUrl(u.getAvatarUrl())
+          .isVerified(u.isVerified())
+          .build();
+    }).toList();
+
+    return FollowListResponse.builder()
+        .items(items)
+        .page(pageRes.getNumber())
+        .size(pageRes.getSize())
+        .totalElements(pageRes.getTotalElements())
+        .totalPages(pageRes.getTotalPages())
+        .build();
+  }
+
+  @Transactional(readOnly = true)
+  public boolean isFollowing(Long viewerUserId, Long targetProfileId) {
+    if (viewerUserId == null) return false;
+    var viewerProfile = profileRepo.findByUserId(viewerUserId).orElse(null);
+    if (viewerProfile == null) return false;
+    return followRepo.existsByFollower_IdAndFollowed_Id(viewerProfile.getId(), targetProfileId);
+  }
+}
+

--- a/src/main/resources/db/migration/V2__profile_follow_table.sql
+++ b/src/main/resources/db/migration/V2__profile_follow_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS profile_follows (
+  id BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+  follower_profile_id BIGINT NOT NULL REFERENCES profiles(id),
+  followed_profile_id BIGINT NOT NULL REFERENCES profiles(id),
+  created_at TIMESTAMP,
+  updated_at TIMESTAMP,
+  CONSTRAINT ux_follow_unique UNIQUE (follower_profile_id, followed_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_follow_follower ON profile_follows(follower_profile_id);
+CREATE INDEX IF NOT EXISTS idx_follow_followed ON profile_follows(followed_profile_id);
+
+ALTER TABLE profile_stats
+  ADD COLUMN IF NOT EXISTS following_count INT DEFAULT 0;


### PR DESCRIPTION
## Summary
- implement `ProfileFollow` entity, repository, service and controller endpoints for following/unfollowing and list views
- extend profile DTOs and service to expose follower/following counts and viewer follow status
- add flyway migration and CORS config entries for follow routes

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b76881512c832eb4a0b2d40fd090ca