### PR TITLE
Enable automatic schema creation for H2

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,9 +21,7 @@ spring:
     username: sa
   jpa:
     hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate.hbm2ddl.auto: none
+      ddl-auto: update
     flyway:
       enabled: true
 


### PR DESCRIPTION
## Summary
- ensure Hibernate auto-creates tables by switching `ddl-auto` to `update`

## Testing
- `mvn -q test` *(fails: Network is unreachable and parent POM cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68b888ddacd8832ea6f11bce1d1146c0