### PR TITLE
Enable automatic schema creation for H2

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/model/profile/ProfileFollow.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/model/profile/ProfileFollow.java
@@ -5,12 +5,9 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "profile_follows",
-    uniqueConstraints = @UniqueConstraint(name = "ux_follow_unique", columnNames = {"follower_profile_id","followed_profile_id"}),
-    indexes = {
-        @Index(name="idx_follow_follower", columnList = "follower_profile_id"),
-        @Index(name="idx_follow_followed", columnList = "followed_profile_id")
-    }
+@Table(
+    name = "profile_follows",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"follower_profile_id", "followed_profile_id"})
 )
 @Getter @Setter @Builder @NoArgsConstructor @AllArgsConstructor
 public class ProfileFollow extends BaseTime {
@@ -19,11 +16,11 @@ public class ProfileFollow extends BaseTime {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name="follower_profile_id", nullable=false, foreignKey = @ForeignKey(name="fk_follow_follower"))
+  @JoinColumn(name = "follower_profile_id", nullable = false)
   private Profile follower;   // takip eden
 
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
-  @JoinColumn(name="followed_profile_id", nullable=false, foreignKey = @ForeignKey(name="fk_follow_followed"))
+  @JoinColumn(name = "followed_profile_id", nullable = false)
   private Profile followed;   // takip edilen
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,15 +17,11 @@ spring:
       enabled: true
       path: /h2
   datasource:
-    url: jdbc:h2:mem:gmdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1
+    url: jdbc:h2:mem:gmdb;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
     username: sa
   jpa:
     hibernate:
-      ddl-auto: validate
-    properties:
-      hibernate.hbm2ddl.auto: none
-    flyway:
-      enabled: true
+      ddl-auto: create-drop
 
   management:
     endpoints:


### PR DESCRIPTION
## Summary
- ensure Hibernate auto-creates tables by switching `ddl-auto` to `create-drop`
- reset in-memory schema each startup by removing `DB_CLOSE_DELAY`
- simplify profile-follow entity by dropping explicit index and foreign key names to avoid duplicate DDL errors

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to "Network is unreachable")*

------
https://chatgpt.com/codex/tasks/task_e_68b888ddacd8832ea6f11bce1d1146c0