### PR TITLE
fix: enable CORS for all origins

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
@@ -13,23 +13,23 @@ public class CorsConfig {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-            .allowedOrigins("http://localhost:3000")
-            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
 
         registry.addMapping("/api/v1/profiles/*/follow")
-            .allowedOrigins("http://localhost:3000")
-            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
 
         registry.addMapping("/api/v1/profiles/*/followers")
-            .allowedOrigins("http://localhost:3000")
-            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
 
         registry.addMapping("/api/v1/profiles/*/following")
-            .allowedOrigins("http://localhost:3000")
-            .allowedMethods("GET","POST","PUT","PATCH","DELETE","OPTIONS")
+            .allowedOriginPatterns("*")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
       }
     };

--- a/src/main/java/com/api/garagemint/garagemintapi/config/SecurityConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/SecurityConfig.java
@@ -48,9 +48,9 @@ public class SecurityConfig {
 
   private CorsConfigurationSource corsSource() {
     CorsConfiguration cfg = new CorsConfiguration();
-    cfg.setAllowedOrigins(List.of("http://localhost:3000", "http://127.0.0.1:3000"));
-    cfg.setAllowedMethods(List.of("GET","POST","PUT","DELETE","PATCH","OPTIONS"));
-    cfg.setAllowedHeaders(List.of("Authorization","Content-Type"));
+    cfg.setAllowedOriginPatterns(List.of("*"));
+    cfg.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+    cfg.setAllowedHeaders(List.of("Authorization", "Content-Type"));
     cfg.setAllowCredentials(true);
     UrlBasedCorsConfigurationSource src = new UrlBasedCorsConfigurationSource();
     src.registerCorsConfiguration("/**", cfg);


### PR DESCRIPTION
## Summary
- allow wildcard CORS configuration for Spring Security
- relax CORS mappings for API endpoints to accept any origin

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2ef4317c832e8489007c5cdb60d7