### PR TITLE
Add uid claim to JWT and auto-provision /me profile

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/profile/ProfileController.java
@@ -1,11 +1,13 @@
 package com.api.garagemint.garagemintapi.controller.profile;
 
 import com.api.garagemint.garagemintapi.dto.profile.*;
+import com.api.garagemint.garagemintapi.security.AuthUser;
 import com.api.garagemint.garagemintapi.security.SecurityUtil;
 import com.api.garagemint.garagemintapi.service.profile.ProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 import java.util.List;
 
@@ -37,16 +39,15 @@ public class ProfileController {
 
     // ---- Owner Endpoints ----
 
+    @Deprecated
     @PostMapping("/me/init")
-    public ProfileOwnerDto initMyProfile() {
-        Long uid = SecurityUtil.getCurrentUserId();
-        return profileService.ensureMyProfile(uid);
+    public ProfileOwnerDto initMyProfile(@AuthenticationPrincipal AuthUser me) {
+        return profileService.ensureMyProfile(me.id());
     }
 
     @GetMapping("/me")
-    public ProfileOwnerDto getMyProfile() {
-        Long uid = SecurityUtil.getCurrentUserId();
-        return profileService.getMyProfile(uid);
+    public ProfileOwnerDto getMyProfile(@AuthenticationPrincipal AuthUser me) {
+        return profileService.ensureMyProfile(me.id());
     }
 
     @PutMapping("/me")

--- a/src/main/java/com/api/garagemint/garagemintapi/security/AuthUser.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/security/AuthUser.java
@@ -1,0 +1,3 @@
+package com.api.garagemint.garagemintapi.security;
+
+public record AuthUser(Long id, String username) {}

--- a/src/main/java/com/api/garagemint/garagemintapi/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/security/JwtAuthenticationFilter.java
@@ -3,11 +3,14 @@ package com.api.garagemint.garagemintapi.security;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 
 import java.io.IOException;
+import java.util.List;
 
 public class JwtAuthenticationFilter extends GenericFilter {
 
@@ -18,30 +21,29 @@ public class JwtAuthenticationFilter extends GenericFilter {
   @Override
   public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
     HttpServletRequest http = (HttpServletRequest) req;
+    HttpServletResponse httpRes = (HttpServletResponse) res;
     String auth = http.getHeader("Authorization");
     if (StringUtils.hasText(auth) && auth.startsWith("Bearer ")) {
       String token = auth.substring(7);
       try {
-        var jws = jwt.parse(token);
-        Claims c = jws.getBody();
-        Long userId = Long.valueOf(c.getSubject());
-        String username = (String) c.get("u");
-        String role = "ROLE_" + (String) c.get("r");
-
-        var principal = new AuthenticatedUser(userId, username, role);
-        var authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+        Claims c = jwt.parse(token).getBody();
+        Number uidNum = c.get("uid", Number.class);
+        if (uidNum == null) {
+          httpRes.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+          return;
+        }
+        long userId = uidNum.longValue();
+        String username = c.getSubject();
+        String role = c.get("role", String.class);
+        var principal = new AuthUser(userId, username);
+        var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + (role != null ? role : "USER")));
+        var authentication = new UsernamePasswordAuthenticationToken(principal, null, authorities);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-      } catch (Exception ignored) {}
+      } catch (Exception e) {
+        httpRes.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+      }
     }
     chain.doFilter(req, res);
-  }
-
-  public static class AuthenticatedUser extends org.springframework.security.core.userdetails.User {
-    private final Long userId;
-    public AuthenticatedUser(Long userId, String username, String role) {
-      super(username, "", java.util.List.of(new org.springframework.security.core.authority.SimpleGrantedAuthority(role)));
-      this.userId = userId;
-    }
-    public Long getUserId() { return userId; }
   }
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/security/JwtService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/security/JwtService.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Instant;
 import java.util.Date;
-import java.util.Map;
 
 @Service
 public class JwtService {
@@ -34,8 +33,12 @@ public class JwtService {
     Instant exp = now.plusSeconds(accessExpMin * 60);
     return Jwts.builder()
         .setIssuer(issuer)
-        .setSubject(String.valueOf(userId))
-        .setClaims(Map.of("u", username, "r", role))
+        // sub = username
+        .setSubject(username)
+        // mandatory user id claim
+        .claim("uid", userId)
+        // optional role claim
+        .claim("role", role)
         .setIssuedAt(Date.from(now))
         .setExpiration(Date.from(exp))
         .signWith(key, SignatureAlgorithm.HS256)

--- a/src/main/java/com/api/garagemint/garagemintapi/security/SecurityUtil.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/security/SecurityUtil.java
@@ -7,7 +7,7 @@ public final class SecurityUtil {
   private SecurityUtil() {}
   public static Long getCurrentUserId() {
     Authentication a = SecurityContextHolder.getContext().getAuthentication();
-    if (a == null || !(a.getPrincipal() instanceof JwtAuthenticationFilter.AuthenticatedUser p)) return null;
-    return p.getUserId();
+    if (a == null || !(a.getPrincipal() instanceof AuthUser p)) return null;
+    return p.id();
   }
 }


### PR DESCRIPTION
## Summary
- Include mandatory `uid` and optional `role` claims in generated JWTs
- Validate `uid` in `JwtAuthenticationFilter` and build `AuthUser` principal
- Auto-create missing profiles from `/api/v1/profiles/me` and deprecate `/me/init`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc06608f20832e89caeb371cff230b