### PR TITLE
Secure /me endpoint and restrict auth routes

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/config/SecurityConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
       .cors(cors -> cors.configurationSource(corsSource()))
       .sessionManagement(sm -> sm.sessionCreationPolicy(org.springframework.security.config.http.SessionCreationPolicy.STATELESS))
       .authorizeHttpRequests(auth -> auth
-        .requestMatchers("/api/v1/auth/**").permitAll()
+        .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login").permitAll()
+        .requestMatchers("/api/v1/auth/me").authenticated()
         .requestMatchers("/api/v1/profiles/*").permitAll()
         .requestMatchers(HttpMethod.GET, "/api/v1/listings", "/api/v1/listings/*").permitAll()
         .requestMatchers("/h2/**", "/actuator/**").permitAll()

--- a/src/main/java/com/api/garagemint/garagemintapi/controller/auth/AuthController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/auth/AuthController.java
@@ -27,7 +27,6 @@ public class AuthController {
   @GetMapping("/me")
   public MeDto me() {
     Long uid = SecurityUtil.getCurrentUserId();
-    if (uid == null) throw new RuntimeException("unauthorized");
     return auth.me(uid);
   }
 }

--- a/src/test/java/com/api/garagemint/garagemintapi/controller/auth/AuthControllerSecurityTest.java
+++ b/src/test/java/com/api/garagemint/garagemintapi/controller/auth/AuthControllerSecurityTest.java
@@ -1,0 +1,26 @@
+package com.api.garagemint.garagemintapi.controller.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AuthControllerSecurityTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  void meEndpointRequiresAuthentication() throws Exception {
+    mockMvc.perform(get("/api/v1/auth/me"))
+        .andExpect(status().isUnauthorized());
+  }
+}
+


### PR DESCRIPTION
## Summary
- Restrict unauthenticated routes to only register and login endpoints
- Require authentication for `/api/v1/auth/me` and remove redundant null check
- Add test ensuring `/api/v1/auth/me` returns 401 when unauthenticated

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c050748832e847c68fa326ff808