### PR TITLE
Log API exceptions for clearer server errors

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/controller/ApiExceptionHandler.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/ApiExceptionHandler.java
@@ -3,6 +3,7 @@ package com.api.garagemint.garagemintapi.controller;
 import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
 import com.api.garagemint.garagemintapi.service.exception.NotFoundException;
 import com.api.garagemint.garagemintapi.service.exception.ValidationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
@@ -11,6 +12,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Slf4j
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
@@ -19,22 +21,26 @@ public class ApiExceptionHandler {
 
   @ExceptionHandler(NotFoundException.class)
   public ResponseEntity<ApiError> handleNotFound(NotFoundException ex) {
+    log.error("NotFoundException: {}", ex.getMessage(), ex);
     return build(HttpStatus.NOT_FOUND, "NOT_FOUND", ex.getMessage(), null);
   }
 
   @ExceptionHandler(ValidationException.class)
   public ResponseEntity<ApiError> handleValidation(ValidationException ex) {
+    log.error("ValidationException: {}", ex.getMessage(), ex);
     return build(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", ex.getMessage(), null);
   }
 
   @ExceptionHandler(BusinessRuleException.class)
   public ResponseEntity<ApiError> handleBusiness(BusinessRuleException ex) {
+    log.error("BusinessRuleException: {}", ex.getMessage(), ex);
     return build(HttpStatus.CONFLICT, "BUSINESS_RULE_VIOLATION", ex.getMessage(), null);
   }
 
   // Bean Validation (@Valid) alan hataları
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ResponseEntity<ApiError> handleBeanValidation(MethodArgumentNotValidException ex) {
+    log.error("MethodArgumentNotValidException: {}", ex.getMessage(), ex);
     Map<String,String> fields = new LinkedHashMap<>();
     ex.getBindingResult().getFieldErrors()
         .forEach(fe -> fields.put(fe.getField(), fe.getDefaultMessage()));
@@ -44,6 +50,7 @@ public class ApiExceptionHandler {
   // En sonda genel yakalayıcı
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ApiError> handleOther(Exception ex) {
+    log.error("Exception: {}", ex.getMessage(), ex);
     return build(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", ex.getMessage(), null);
   }
 


### PR DESCRIPTION
## Summary
- add Lombok `@Slf4j` logger to `ApiExceptionHandler`
- record each handled exception with `log.error`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network unreachable)*
- `mvn -q spring-boot:run` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c1bbdc4832ea52918f046f555c0