### PR TITLE
refactor: use enums for listing dto fields

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/controller/cars/ListingController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/cars/ListingController.java
@@ -3,6 +3,9 @@ package com.api.garagemint.garagemintapi.controller.cars;
 import com.api.garagemint.garagemintapi.dto.cars.*;
 import com.api.garagemint.garagemintapi.security.SecurityUtil;
 import com.api.garagemint.garagemintapi.service.cars.ListingService;
+import com.api.garagemint.garagemintapi.model.cars.Condition;
+import com.api.garagemint.garagemintapi.model.cars.ListingType;
+import com.api.garagemint.garagemintapi.model.cars.ListingStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,10 +37,10 @@ public class ListingController {
       @RequestParam(required = false) List<Long> tagIds,
       @RequestParam(required = false) String theme,
       @RequestParam(required = false) String scale,
-      @RequestParam(required = false) String condition,
+      @RequestParam(required = false) Condition condition,
       @RequestParam(required = false) Boolean limitedEdition,
-      @RequestParam(required = false) String type,
-      @RequestParam(required = false) String status,
+      @RequestParam(required = false) ListingType type,
+      @RequestParam(required = false) ListingStatus status,
       @RequestParam(required = false) String location,
       @RequestParam(required = false) Short modelYearFrom,
       @RequestParam(required = false) Short modelYearTo,
@@ -105,7 +108,7 @@ public class ListingController {
   }
 
   @PatchMapping("/{id}/status")
-  public ListingResponseDto patchStatus(@PathVariable Long id, @RequestParam String status) {
+  public ListingResponseDto patchStatus(@PathVariable Long id, @RequestParam ListingStatus status) {
     Long currentUserId = SecurityUtil.getCurrentUserId();
     return listingService.patchStatus(currentUserId, id, status);
   }

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingCreateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingCreateRequest.java
@@ -5,6 +5,9 @@ import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.api.garagemint.garagemintapi.model.cars.Condition;
+import com.api.garagemint.garagemintapi.model.cars.ListingType;
+
 @Getter @Setter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class ListingCreateRequest {
@@ -30,8 +33,7 @@ public class ListingCreateRequest {
 
   private Short modelYear;
 
-  @Size(max=24)
-  private String condition;       // "NEW","MINT","USED","CUSTOM" (enum-like string)
+  private Condition condition;       // NEW/MINT/USED/CUSTOM
 
   private Boolean limitedEdition; // default false
 
@@ -42,8 +44,8 @@ public class ListingCreateRequest {
   private String countryOfOrigin;
 
   // ---- Fiyat ----
-  @NotBlank @Size(max=16)
-  private String type;            // "SALE" veya "TRADE"
+  @NotNull
+  private ListingType type;            // SALE veya TRADE
 
   @Positive
   private BigDecimal price;       // TRADE ise null olabilir

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingFilterRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingFilterRequest.java
@@ -5,6 +5,10 @@ import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.api.garagemint.garagemintapi.model.cars.Condition;
+import com.api.garagemint.garagemintapi.model.cars.ListingStatus;
+import com.api.garagemint.garagemintapi.model.cars.ListingType;
+
 @Getter @Setter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class ListingFilterRequest {
@@ -19,11 +23,11 @@ public class ListingFilterRequest {
 
   private String theme;            // tekil string filtresi
   private String scale;            // "1:64"
-  private String condition;        // "NEW","MINT","USED","CUSTOM"
+  private Condition condition;        // NEW/MINT/USED/CUSTOM
   private Boolean limitedEdition;
 
-  private String type;             // "SALE" / "TRADE"
-  private String status;           // "ACTIVE","INACTIVE","SOLD"
+  private ListingType type;             // SALE / TRADE
+  private ListingStatus status;           // ACTIVE/INACTIVE/SOLD
 
   private String location;         // free-text
 

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingModerationUpdateRequest.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingModerationUpdateRequest.java
@@ -2,9 +2,11 @@ package com.api.garagemint.garagemintapi.dto.cars;
 
 import lombok.*;
 
+import com.api.garagemint.garagemintapi.model.cars.ListingStatus;
+
 @Getter @Setter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class ListingModerationUpdateRequest {
   private Boolean isActive;   // admin override: feed’de görünmesin/görünsün
-  private String status;      // admin düzeltmesi gerekiyorsa
+  private ListingStatus status;      // admin düzeltmesi gerekiyorsa
 }

--- a/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingResponseDto.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/dto/cars/ListingResponseDto.java
@@ -4,6 +4,10 @@ import lombok.*;
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.api.garagemint.garagemintapi.model.cars.Condition;
+import com.api.garagemint.garagemintapi.model.cars.ListingStatus;
+import com.api.garagemint.garagemintapi.model.cars.ListingType;
+
 @Getter @Setter @Builder
 @NoArgsConstructor @AllArgsConstructor
 public class ListingResponseDto {
@@ -25,19 +29,19 @@ public class ListingResponseDto {
   private String modelName;
   private String scale;
   private Short modelYear;
-  private String condition;
+  private Condition condition;
   private Boolean limitedEdition;
   private String theme;
   private String countryOfOrigin;
 
   // Fiyat
-  private String type;         // SALE/TRADE
+  private ListingType type;         // SALE/TRADE
   private BigDecimal price;    // null → TRADE
   private String currency;
   private String location;
 
   // Moderasyon & state
-  private String status;       // ACTIVE/INACTIVE/SOLD
+  private ListingStatus status;       // ACTIVE/INACTIVE/SOLD
   private Boolean isActive;    // admin override
 
   // Zamanlar (ISO-8601)

--- a/src/main/java/com/api/garagemint/garagemintapi/mapper/cars/ListingMapper.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/mapper/cars/ListingMapper.java
@@ -22,11 +22,6 @@ public interface ListingMapper {
   @Mapping(target = "brandName", ignore = true)
   @Mapping(target = "seriesName", ignore = true)
 
-  // enum → String
-  @Mapping(target = "type", expression = "java(entity.getType()==null?null:entity.getType().name())")
-  @Mapping(target = "status", expression = "java(entity.getStatus()==null?null:entity.getStatus().name())")
-  @Mapping(target = "condition", expression = "java(entity.getCondition()==null?null:entity.getCondition().name())")
-
   // Instant → ISO-8601 String
   @Mapping(target = "createdAt", source = "createdAt", qualifiedByName = "iso")
   @Mapping(target = "updatedAt", source = "updatedAt", qualifiedByName = "iso")
@@ -39,15 +34,6 @@ public interface ListingMapper {
   @Mapping(target = "sellerUserId", ignore = true)
   @Mapping(target = "status", ignore = true)
   @Mapping(target = "isActive", ignore = true)
-  // enum-like String → Enum (null toleranslı) — FQCN kullan!
-  @Mapping(
-          target = "type",
-          expression = "java(req.getType()==null ? null : com.api.garagemint.garagemintapi.model.cars.ListingType.valueOf(req.getType().toUpperCase()))"
-  )
-  @Mapping(
-          target = "condition",
-          expression = "java(req.getCondition()==null ? null : com.api.garagemint.garagemintapi.model.cars.Condition.valueOf(req.getCondition().toUpperCase()))"
-  )
   @Mapping(target = "price", source = "price")
   @Mapping(target = "brandId", source = "brandId")
   @Mapping(target = "seriesId", source = "seriesId")
@@ -55,7 +41,7 @@ public interface ListingMapper {
 
   /* ========= Update DTO -> mevcut Entity ========= */
 
-  // Sadece gelen alanları günceller (null’lar dokunmaz); enum-stringleri parse ederiz. — FQCN kullan!
+  // Sadece gelen alanları günceller (null’lar dokunmaz)
   @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
   void updateEntity(@MappingTarget Listing entity, ListingUpdateRequest req);
 


### PR DESCRIPTION
## Summary
- use enum types for listing type, condition and status fields in DTOs
- simplify mapper and service logic to work with enums directly
- update controllers to accept enums in requests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c19468c832e88a1198f7a8f56a9