### PR TITLE
Add tests for auth and listing services

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -19,3 +19,10 @@ spring:
     console:
       enabled: true
       path: /h2
+
+app:
+  security:
+    jwt:
+      secret: test-secret
+      access-exp-min: 60
+      issuer: garagemint-test

--- a/src/test/java/com/api/garagemint/garagemintapi/controller/auth/AuthControllerTest.java
+++ b/src/test/java/com/api/garagemint/garagemintapi/controller/auth/AuthControllerTest.java
@@ -1,0 +1,86 @@
+package com.api.garagemint.garagemintapi.controller.auth;
+
+import com.api.garagemint.garagemintapi.dto.auth.JwtTokensDto;
+import com.api.garagemint.garagemintapi.dto.auth.LoginRequest;
+import com.api.garagemint.garagemintapi.dto.auth.RegisterRequest;
+import com.api.garagemint.garagemintapi.service.auth.AuthService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void registerSuccess() throws Exception {
+        JwtTokensDto tokens = JwtTokensDto.builder().accessToken("abc").tokenType("Bearer").build();
+        when(authService.register(any(RegisterRequest.class))).thenReturn(tokens);
+
+        RegisterRequest req = RegisterRequest.builder()
+                .email("user@example.com")
+                .username("user123")
+                .password("password123")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("abc"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"));
+    }
+
+    @Test
+    void registerValidationError() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void loginSuccess() throws Exception {
+        JwtTokensDto tokens = JwtTokensDto.builder().accessToken("xyz").tokenType("Bearer").build();
+        when(authService.login(any(LoginRequest.class))).thenReturn(tokens);
+
+        LoginRequest req = LoginRequest.builder()
+                .emailOrUsername("user")
+                .password("password123")
+                .build();
+
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("xyz"))
+                .andExpect(jsonPath("$.tokenType").value("Bearer"));
+    }
+
+    @Test
+    void loginValidationError() throws Exception {
+        mockMvc.perform(post("/api/v1/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/api/garagemint/garagemintapi/service/cars/ListingServiceTest.java
+++ b/src/test/java/com/api/garagemint/garagemintapi/service/cars/ListingServiceTest.java
@@ -1,0 +1,100 @@
+package com.api.garagemint.garagemintapi.service.cars;
+
+import com.api.garagemint.garagemintapi.dto.cars.ListingCreateRequest;
+import com.api.garagemint.garagemintapi.dto.cars.ListingResponseDto;
+import com.api.garagemint.garagemintapi.mapper.cars.ListingMapper;
+import com.api.garagemint.garagemintapi.model.cars.*;
+import com.api.garagemint.garagemintapi.repository.cars.*;
+import com.api.garagemint.garagemintapi.repository.profiles.ProfileRepository;
+import com.api.garagemint.garagemintapi.service.exception.BusinessRuleException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ListingServiceTest {
+
+    private ListingRepository listingRepo;
+    private ListingImageRepository imageRepo;
+    private ListingTagRepository listingTagRepo;
+    private TagRepository tagRepo;
+    private BrandRepository brandRepo;
+    private SeriesRepository seriesRepo;
+    private ProfileRepository profileRepo;
+    private ListingMapper mapper;
+
+    private ListingService service;
+
+    @BeforeEach
+    void setUp() {
+        listingRepo = mock(ListingRepository.class);
+        imageRepo = mock(ListingImageRepository.class);
+        listingTagRepo = mock(ListingTagRepository.class);
+        tagRepo = mock(TagRepository.class);
+        brandRepo = mock(BrandRepository.class);
+        seriesRepo = mock(SeriesRepository.class);
+        profileRepo = mock(ProfileRepository.class);
+        mapper = mock(ListingMapper.class);
+
+        service = Mockito.spy(new ListingService(
+                listingRepo, imageRepo, listingTagRepo, tagRepo, brandRepo, seriesRepo, profileRepo, mapper));
+    }
+
+    @Test
+    void createSuccess() {
+        ListingCreateRequest req = ListingCreateRequest.builder()
+                .title("My Listing")
+                .type("SALE")
+                .price(BigDecimal.TEN)
+                .currency("USD")
+                .build();
+
+        Listing entity = Listing.builder()
+                .type(ListingType.SALE)
+                .price(BigDecimal.TEN)
+                .currency("USD")
+                .build();
+
+        Listing saved = Listing.builder()
+                .id(1L)
+                .type(ListingType.SALE)
+                .price(BigDecimal.TEN)
+                .currency("USD")
+                .build();
+
+        ListingResponseDto resp = ListingResponseDto.builder().id(1L).build();
+
+        when(listingRepo.countBySellerUserIdAndStatus(anyLong(), eq(ListingStatus.ACTIVE))).thenReturn(0L);
+        when(mapper.toEntity(req)).thenReturn(entity);
+        when(listingRepo.save(entity)).thenReturn(saved);
+        doReturn(resp).when(service).assembleResponse(1L);
+        doNothing().when(imageRepo).deleteByListingId(anyLong());
+        doNothing().when(listingTagRepo).deleteByIdListingId(anyLong());
+
+        ListingResponseDto out = service.create(5L, req);
+
+        assertNotNull(out);
+        assertEquals(1L, out.getId());
+        verify(listingRepo).save(entity);
+    }
+
+    @Test
+    void createFailsWhenMaxActiveListingsReached() {
+        ListingCreateRequest req = ListingCreateRequest.builder()
+                .title("My Listing")
+                .type("SALE")
+                .price(BigDecimal.TEN)
+                .currency("USD")
+                .build();
+
+        when(listingRepo.countBySellerUserIdAndStatus(anyLong(), eq(ListingStatus.ACTIVE))).thenReturn(3L);
+
+        assertThrows(BusinessRuleException.class, () -> service.create(10L, req));
+        verify(listingRepo, never()).save(any());
+    }
+}


### PR DESCRIPTION
## Summary
- Configure test profile with JWT settings
- Add WebMvc tests for AuthController registration and login flows
- Add ListingService unit tests covering creation success and active listing limit

## Testing
- `mvn -q test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3c1cc260832ebc3a97d88315126f