### PR TITLE
Fix listing status patch parameter type

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/controller/cars/ListingController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/cars/ListingController.java
@@ -116,7 +116,7 @@ public class ListingController {
   public ListingResponseDto patchStatus(
       @AuthenticationPrincipal AuthUser user,
       @PathVariable Long id,
-      @RequestParam String status) {
+      @RequestParam ListingStatus status) {
     return listingService.patchStatus(user.id(), id, status);
 
   }


### PR DESCRIPTION
## Summary
- Fix ListingController's status patch endpoint to accept `ListingStatus` enum instead of raw String

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5436be30832ebd6f1248a9adb33c