### PR TITLE
fix: bind CORS allowed origins property

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/config/CorsConfig.java
@@ -6,38 +6,34 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.util.List;
-
 @Configuration
 public class CorsConfig {
 
   @Value("${cors.allowed-origins}")
-  private List<String> allowedOrigins;
+  private String[] allowedOrigins;
 
   @Bean
   public WebMvcConfigurer corsConfigurer() {
     return new WebMvcConfigurer() {
       @Override
       public void addCorsMappings(CorsRegistry registry) {
-        String[] origins = allowedOrigins.toArray(new String[0]);
-
         registry.addMapping("/api/**")
-            .allowedOrigins(origins)
+            .allowedOrigins(allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
 
         registry.addMapping("/api/v1/profiles/*/follow")
-            .allowedOrigins(origins)
+            .allowedOrigins(allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
 
         registry.addMapping("/api/v1/profiles/*/followers")
-            .allowedOrigins(origins)
+            .allowedOrigins(allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
 
         registry.addMapping("/api/v1/profiles/*/following")
-            .allowedOrigins(origins)
+            .allowedOrigins(allowedOrigins)
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowCredentials(true);
       }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,6 +31,4 @@ spring:
     locations: classpath:db/migration
 
 cors:
-  allowed-origins:
-    - http://localhost:3000
-    - http://localhost:3001
+  allowed-origins: http://localhost:3000,http://localhost:3001

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,5 +27,4 @@ spring:
     locations: classpath:db/migration
 
 cors:
-  allowed-origins:
-    - https://garagemint.com
+  allowed-origins: https://garagemint.com

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -21,9 +21,7 @@ spring:
       path: /h2
 
 cors:
-  allowed-origins:
-    - http://localhost:3000
-    - http://localhost:3001
+  allowed-origins: http://localhost:3000,http://localhost:3001
 
 app:
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,5 +32,4 @@ springdoc:
     path: /swagger
 
 cors:
-  allowed-origins:
-    - https://garagemint.com
+  allowed-origins: https://garagemint.com


### PR DESCRIPTION
## Summary
- adjust `CorsConfig` to read allowed origins as an array
- define `cors.allowed-origins` values using comma-separated strings across environment configs

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc57c8ccc0832e9f73f86033c57cc6