### PR TITLE
feat: list seller auctions

### DIFF
--- a/src/main/java/com/api/garagemint/garagemintapi/controller/auction/AuctionController.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/controller/auction/AuctionController.java
@@ -35,6 +35,14 @@ public class AuctionController {
     return auctionService.getBids(id);
   }
 
+  @GetMapping("/seller")
+  public List<AuctionListItemDto> listBySeller(
+      @AuthenticationPrincipal AuthUser user,
+      @RequestParam(value = "userId", required = false) Long userId) {
+    Long uid = (userId != null) ? userId : (user != null ? user.id() : null);
+    return auctionService.listAuctionsBySeller(uid);
+  }
+
   // ---- Seller ----
   @PostMapping
   public AuctionResponseDto create(

--- a/src/main/java/com/api/garagemint/garagemintapi/repository/auction/AuctionRepository.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/repository/auction/AuctionRepository.java
@@ -17,6 +17,8 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 
   List<Auction> findByStatus(AuctionStatus status);
 
+  List<Auction> findBySellerUserId(Long userId);
+
   /** Teklif anında optimistic lock yeterli; yine de isteğe bağlı PESSIMISTIC_WRITE desteklemek için aşağıdaki method eklenebilir */
   @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
   @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))

--- a/src/main/java/com/api/garagemint/garagemintapi/service/auction/AuctionService.java
+++ b/src/main/java/com/api/garagemint/garagemintapi/service/auction/AuctionService.java
@@ -88,6 +88,27 @@ public class AuctionService {
 
   /* ========= SELLER ========= */
 
+  @Transactional(readOnly = true)
+  public List<AuctionListItemDto> listAuctionsBySeller(Long sellerUserId) {
+    if (sellerUserId == null) throw new ValidationException("sellerUserId is required");
+    return auctionRepo.findBySellerUserId(sellerUserId).stream()
+        .map(a -> {
+            var cover = imageRepo.findFirstByAuctionIdOrderByIdxAsc(a.getId())
+                .map(AuctionImage::getUrl).orElse(null);
+            return AuctionListItemDto.builder()
+                .id(a.getId())
+                .listingId(a.getListingId())
+                .startPrice(a.getStartPrice())
+                .highestBidAmount(a.getHighestBidAmount())
+                .currency(a.getCurrency())
+                .status(a.getStatus())
+                .endsAt(a.getEndsAt())
+                .coverUrl(cover)
+                .build();
+        })
+        .toList();
+  }
+
   @Transactional
   public AuctionResponseDto createAuction(Long sellerUserId, AuctionCreateRequest req) {
     if (sellerUserId == null) throw new ValidationException("sellerUserId is required");


### PR DESCRIPTION
## Summary
- allow fetching auctions by seller user ID
- expose listing endpoint for seller auctions

## Testing
- `mvn -q test` *(failed: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6adeccf4832eac1ef8b2c0ae848d